### PR TITLE
Support for Markdown in the "format" property

### DIFF
--- a/draft-00.html
+++ b/draft-00.html
@@ -12,6 +12,28 @@
 	  a {
 	  text-decoration: none;
 	  }
+      /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+      a.info {
+          /* This is the key. */
+          position: relative;
+          z-index: 24;
+          text-decoration: none;
+      }
+      a.info:hover {
+          z-index: 25;
+          color: #FFF; background-color: #900;
+      }
+      a.info span { display: none; }
+      a.info:hover span.info {
+          /* The span will display just on :hover state. */
+          display: block;
+          position: absolute;
+          font-size: smaller;
+          top: 2em; left: -5em; width: 15em;
+          padding: 2px; border: 1px solid #333;
+          color: #900; background-color: #EEE;
+          text-align: left;
+      }
 	  a.smpl {
 	  color: black;
 	  }
@@ -397,12 +419,12 @@
 <link href="#rfc.appendix.A.3" rel="Chapter" title="A.3 Why is there no way to indicate ranges for semantic descriptors?"/>
 
 
-  <meta name="generator" content="xml2rfc version 2.4.3 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.4.8 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Amundsen, M., Richardson, L., and M. Foster" />
   <meta name="dct.identifier" content="urn:ietf:id:draft-amundsen-richardson-foster-alps-00.J" />
-  <meta name="dct.issued" scheme="ISO8601" content="2014-8-10" />
+  <meta name="dct.issued" scheme="ISO8601" content="2015-1-20" />
   <meta name="dct.abstract" content="This document describes ALPS, a data format for defining simple descriptions of application-level semantics, similar in complexity to HTML microformats. An ALPS document can be used as a profile to explain the application semantics of a document with an application-agnostic media type (such as HTML, HAL, Collection+JSON, Siren, etc.). This increases the reusability of profile documents across media types.  " />
   <meta name="description" content="This document describes ALPS, a data format for defining simple descriptions of application-level semantics, similar in complexity to HTML microformats. An ALPS document can be used as a profile to explain the application semantics of a document with an application-agnostic media type (such as HTML, HAL, Collection+JSON, Siren, etc.). This increases the reusability of profile documents across media types.  " />
 
@@ -422,7 +444,7 @@
   <td class="right">CA Technologies, Inc.</td>
 </tr>
 <tr>
-  <td class="left">Expires: February 11, 2015</td>
+  <td class="left">Expires: July 24, 2015</td>
   <td class="right">L. Richardson</td>
 </tr>
 <tr>
@@ -439,7 +461,7 @@
 </tr>
 <tr>
   <td class="left"></td>
-  <td class="right">August 10, 2014</td>
+  <td class="right">January 20, 2015</td>
 </tr>
 
     	
@@ -463,11 +485,11 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on February 11, 2015.</p>
+<p>This Internet-Draft will expire on July 24, 2015.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
-<p>Copyright (c) 2014 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>Copyright (c) 2015 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
@@ -750,15 +772,7 @@
 
 <p> </p>
 <h1 id="rfc.section.2.2.2"><a href="#rfc.section.2.2.2">2.2.2.</a> <a href="#prop-doc" id="prop-doc">'doc'</a></h1>
-<p id="rfc.section.2.2.2.p.1">A text field that contains free-form, usually human-readable, text.  The 'doc' element MAY have two properties: <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> and <a href="#prop-format">'format'</a> <cite title="NONE">[prop-format]</cite>.  If the 'href' property appears it SHOULD contain a dereferencable URL that points to human-readable text. If the 'format' property appears it SHOULD contain one of the following values: </p>
-
-<ol>
-  <li>"text"</li>
-  <li>"html"</li>
-  <li>"asciidoc"</li>
-</ol>
-
-<p> Any program processing "doc" elements SHOULD honor the "format" directive and parse/render the content appropriately. If the value in the "format" property is not recognized and/or supported, the processing program MUST treat the content as plain text. If no 'format' property is present, the content SHOULD be treated as plain text.  </p>
+<p id="rfc.section.2.2.2.p.1">A text field that contains free-form, usually human-readable, text.  The 'doc' element MAY have two properties: <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> and <a href="#prop-format">'format'</a> <cite title="NONE">[prop-format]</cite>.  If the 'href' property appears it SHOULD contain a dereferencable URL that points to human-readable text. If the 'format' property appears it SHOULD contain one of the following values: "text", "html", "asciidoc", or "markdown".  Any program processing "doc" elements SHOULD honor the "format" directive and parse/render the content appropriately. If the value in the "format" property is not recognized and/or supported, the processing program MUST treat the content as plain text. If no 'format' property is present, the content SHOULD be treated as plain text.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -855,7 +869,17 @@
 <p> </p>
 <p id="rfc.section.2.2.4.p.6">Since the 'ext' element has no specific meaning within this specification, it MUST be ignored by any application that does not understand its meaning.  </p>
 <h1 id="rfc.section.2.2.5"><a href="#rfc.section.2.2.5">2.2.5.</a> <a href="#prop-format" id="prop-format">'format'</a></h1>
-<p id="rfc.section.2.2.5.p.1">Indicates how the text content should be parsed and/or rendered. This version of the spec identifies three possible values for "format": "text", "html", and "asciidoc." Any other values for this attribute are undefined and SHOULD be treated as plain text. If the program does not recognize the value of the "format" property and/or the "format" property is missing, the content SHOULD be treated as plain text.  This property MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> element.  </p>
+<p id="rfc.section.2.2.5.p.1">Indicates how the text content should be parsed and/or rendered. This specification identifies a range of possible values for "format": </p>
+
+<ul>
+  <li>"text", for plain text, MUST be supported.</li>
+  <li>"html", for HTML, SHOULD be supported.</li>
+  <li>"asciidoc", for AsciiDoc, MAY be supported.</li>
+  <li>"markdown", per <a href="#draft-ietf-appsawg-text-markdown-05">The text/markdown Media Type</a> <cite title="NONE">[draft-ietf-appsawg-text-markdown-05]</cite>, MAY be supported.</li>
+</ul>
+
+<p> Any other values for this attribute are undefined and SHOULD be treated as plain text. If the program does not recognize the value of the "format" property and/or the "format" property is missing, the content SHOULD be treated as plain text.  </p>
+<p id="rfc.section.2.2.5.p.2">This property MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> element.  </p>
 <h1 id="rfc.section.2.2.6"><a href="#rfc.section.2.2.6">2.2.6.</a> <a href="#prop-href" id="prop-href">'href'</a></h1>
 <p id="rfc.section.2.2.6.p.1">Contains a resolvable URL.  </p>
 <p id="rfc.section.2.2.6.p.2">When it appears as an attribute of <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>, 'href' points to another 'descriptor' either within the existing ALPS document or in another ALPS document.  </p>
@@ -1199,7 +1223,7 @@
 <p> </p>
 <h1 id="rfc.section.5"><a href="#rfc.section.5">5.</a> <a href="#internationalization" id="internationalization">Internationalization Considerations</a></h1>
 <p id="rfc.section.5.p.1">[TK]</p>
-<p/>
+<p><a id="CREF1" class="info">[CREF1]<span class="info">insert text (consider rfc 5987)</span></a> </p>
 <h1 id="rfc.section.6"><a href="#rfc.section.6">6.</a> Acknowledgements</h1>
 <p id="rfc.section.6.p.1">The following people made contributions to this specification: </p>
 <h1 id="rfc.references"><a href="#rfc.references">7.</a> References</h1>
@@ -1246,6 +1270,12 @@
         <b id="draft-ietf-appsawg-uri-get-off-my-lawn-00">[draft-ietf-appsawg-uri-get-off-my-lawn-00]</b>
       </td>
       <td class="top"><a>Nottingham, M.</a>, "<a>Standardising Structure in URIs</a>", I-D draft-ietf-appsawg-uri-get-off-my-lawn-00, September 2013.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="draft-ietf-appsawg-text-markdown-05">[draft-ietf-appsawg-text-markdown-05]</b>
+      </td>
+      <td class="top"><a>Leonard, S.</a>, "<a>The text/markdown Media Type</a>", I-D draft-ietf-appsawg-text-markdown-05, December 2014.</td>
     </tr>
   </tbody>
 </table>

--- a/draft-00.html
+++ b/draft-00.html
@@ -12,28 +12,6 @@
 	  a {
 	  text-decoration: none;
 	  }
-      /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
-      a.info {
-          /* This is the key. */
-          position: relative;
-          z-index: 24;
-          text-decoration: none;
-      }
-      a.info:hover {
-          z-index: 25;
-          color: #FFF; background-color: #900;
-      }
-      a.info span { display: none; }
-      a.info:hover span.info {
-          /* The span will display just on :hover state. */
-          display: block;
-          position: absolute;
-          font-size: smaller;
-          top: 2em; left: -5em; width: 15em;
-          padding: 2px; border: 1px solid #333;
-          color: #900; background-color: #EEE;
-          text-align: left;
-      }
 	  a.smpl {
 	  color: black;
 	  }
@@ -419,12 +397,12 @@
 <link href="#rfc.appendix.A.3" rel="Chapter" title="A.3 Why is there no way to indicate ranges for semantic descriptors?"/>
 
 
-  <meta name="generator" content="xml2rfc version 2.4.8 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.4.3 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Amundsen, M., Richardson, L., and M. Foster" />
   <meta name="dct.identifier" content="urn:ietf:id:draft-amundsen-richardson-foster-alps-00.J" />
-  <meta name="dct.issued" scheme="ISO8601" content="2015-1-19" />
+  <meta name="dct.issued" scheme="ISO8601" content="2014-8-10" />
   <meta name="dct.abstract" content="This document describes ALPS, a data format for defining simple descriptions of application-level semantics, similar in complexity to HTML microformats. An ALPS document can be used as a profile to explain the application semantics of a document with an application-agnostic media type (such as HTML, HAL, Collection+JSON, Siren, etc.). This increases the reusability of profile documents across media types.  " />
   <meta name="description" content="This document describes ALPS, a data format for defining simple descriptions of application-level semantics, similar in complexity to HTML microformats. An ALPS document can be used as a profile to explain the application semantics of a document with an application-agnostic media type (such as HTML, HAL, Collection+JSON, Siren, etc.). This increases the reusability of profile documents across media types.  " />
 
@@ -444,7 +422,7 @@
   <td class="right">CA Technologies, Inc.</td>
 </tr>
 <tr>
-  <td class="left">Expires: July 23, 2015</td>
+  <td class="left">Expires: February 11, 2015</td>
   <td class="right">L. Richardson</td>
 </tr>
 <tr>
@@ -461,7 +439,7 @@
 </tr>
 <tr>
   <td class="left"></td>
-  <td class="right">January 19, 2015</td>
+  <td class="right">August 10, 2014</td>
 </tr>
 
     	
@@ -485,11 +463,11 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on July 23, 2015.</p>
+<p>This Internet-Draft will expire on February 11, 2015.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
-<p>Copyright (c) 2015 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>Copyright (c) 2014 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
@@ -772,8 +750,7 @@
 
 <p> </p>
 <h1 id="rfc.section.2.2.2"><a href="#rfc.section.2.2.2">2.2.2.</a> <a href="#prop-doc" id="prop-doc">'doc'</a></h1>
-<p id="rfc.section.2.2.2.p.1">A text field that contains free-form, usually human-readable, text.  </p>
-<p id="rfc.section.2.2.2.p.2">The 'doc' element MAY have two properties: <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> and <a href="#prop-format">'format'</a> <cite title="NONE">[prop-format]</cite>.  If the 'href' property appears it SHOULD contain a dereferencable URL that points to human-readable text. If the 'format' property appears it SHOULD contain one of the following values: </p>
+<p id="rfc.section.2.2.2.p.1">A text field that contains free-form, usually human-readable, text.  The 'doc' element MAY have two properties: <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> and <a href="#prop-format">'format'</a> <cite title="NONE">[prop-format]</cite>.  If the 'href' property appears it SHOULD contain a dereferencable URL that points to human-readable text. If the 'format' property appears it SHOULD contain one of the following values: </p>
 
 <ol>
   <li>"text"</li>
@@ -781,9 +758,7 @@
   <li>"asciidoc"</li>
 </ol>
 
-<p> </p>
-<p id="rfc.section.2.2.2.p.3">Any program processing "doc" elements SHOULD honor the "format" directive and parse/render the content appropriately. If the value in the "format" property is not recognized and/or supported, the processing program MUST treat the content as plain text. If no 'format' property is present, the content SHOULD be treated as plain text. Support for additional formats, such as <a href="#draft-ietf-appsawg-text-markdown-05">Markdown</a> <cite title="NONE">[draft-ietf-appsawg-text-markdown-05]</cite>, MAY be considered in the future.  </p>
-<p/>
+<p> Any program processing "doc" elements SHOULD honor the "format" directive and parse/render the content appropriately. If the value in the "format" property is not recognized and/or supported, the processing program MUST treat the content as plain text. If no 'format' property is present, the content SHOULD be treated as plain text.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -793,7 +768,7 @@
 </dl>
 
 <p> </p>
-<p id="rfc.section.2.2.2.p.5">A 'doc' element SHOULD appear as a child of <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>. When present, it describes the meaning and use of the related 'descriptor'.  </p>
+<p id="rfc.section.2.2.2.p.2">A 'doc' element SHOULD appear as a child of <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>. When present, it describes the meaning and use of the related 'descriptor'.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -803,7 +778,7 @@
 </dl>
 
 <p> </p>
-<p id="rfc.section.2.2.2.p.6">The 'doc' element MAY appear as a child of <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite>. When present, it describes the purpose of the ALPS document as a whole.  </p>
+<p id="rfc.section.2.2.2.p.3">The 'doc' element MAY appear as a child of <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite>. When present, it describes the purpose of the ALPS document as a whole.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -880,8 +855,7 @@
 <p> </p>
 <p id="rfc.section.2.2.4.p.6">Since the 'ext' element has no specific meaning within this specification, it MUST be ignored by any application that does not understand its meaning.  </p>
 <h1 id="rfc.section.2.2.5"><a href="#rfc.section.2.2.5">2.2.5.</a> <a href="#prop-format" id="prop-format">'format'</a></h1>
-<p id="rfc.section.2.2.5.p.1">Indicates how the text content should be parsed and/or rendered. This version of the spec identifies three possible values for "format": "text", "html", and "asciidoc." Any other values for this attribute are undefined and SHOULD be treated as plain text. If the program does not recognize the value of the "format" property and/or the "format" property is missing, the content SHOULD be treated as plain text. Support for additional formats MAY be considered in the future.  </p>
-<p id="rfc.section.2.2.5.p.2">This property MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> element.  </p>
+<p id="rfc.section.2.2.5.p.1">Indicates how the text content should be parsed and/or rendered. This version of the spec identifies three possible values for "format": "text", "html", and "asciidoc." Any other values for this attribute are undefined and SHOULD be treated as plain text. If the program does not recognize the value of the "format" property and/or the "format" property is missing, the content SHOULD be treated as plain text.  This property MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> element.  </p>
 <h1 id="rfc.section.2.2.6"><a href="#rfc.section.2.2.6">2.2.6.</a> <a href="#prop-href" id="prop-href">'href'</a></h1>
 <p id="rfc.section.2.2.6.p.1">Contains a resolvable URL.  </p>
 <p id="rfc.section.2.2.6.p.2">When it appears as an attribute of <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>, 'href' points to another 'descriptor' either within the existing ALPS document or in another ALPS document.  </p>
@@ -1225,7 +1199,7 @@
 <p> </p>
 <h1 id="rfc.section.5"><a href="#rfc.section.5">5.</a> <a href="#internationalization" id="internationalization">Internationalization Considerations</a></h1>
 <p id="rfc.section.5.p.1">[TK]</p>
-<p><a id="CREF1" class="info">[CREF1]<span class="info">insert text (consider rfc 5987)</span></a> </p>
+<p/>
 <h1 id="rfc.section.6"><a href="#rfc.section.6">6.</a> Acknowledgements</h1>
 <p id="rfc.section.6.p.1">The following people made contributions to this specification: </p>
 <h1 id="rfc.references"><a href="#rfc.references">7.</a> References</h1>
@@ -1272,12 +1246,6 @@
         <b id="draft-ietf-appsawg-uri-get-off-my-lawn-00">[draft-ietf-appsawg-uri-get-off-my-lawn-00]</b>
       </td>
       <td class="top"><a>Nottingham, M.</a>, "<a>Standardising Structure in URIs</a>", I-D draft-ietf-appsawg-uri-get-off-my-lawn-00, September 2013.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="draft-ietf-appsawg-text-markdown-05">[draft-ietf-appsawg-text-markdown-05]</b>
-      </td>
-      <td class="top"><a>Leonard, S.</a>, "<a>The text/markdown Media Type</a>", I-D draft-ietf-appsawg-text-markdown-05, December 2014.</td>
     </tr>
   </tbody>
 </table>

--- a/draft-00.html
+++ b/draft-00.html
@@ -12,6 +12,28 @@
 	  a {
 	  text-decoration: none;
 	  }
+      /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+      a.info {
+          /* This is the key. */
+          position: relative;
+          z-index: 24;
+          text-decoration: none;
+      }
+      a.info:hover {
+          z-index: 25;
+          color: #FFF; background-color: #900;
+      }
+      a.info span { display: none; }
+      a.info:hover span.info {
+          /* The span will display just on :hover state. */
+          display: block;
+          position: absolute;
+          font-size: smaller;
+          top: 2em; left: -5em; width: 15em;
+          padding: 2px; border: 1px solid #333;
+          color: #900; background-color: #EEE;
+          text-align: left;
+      }
 	  a.smpl {
 	  color: black;
 	  }
@@ -397,12 +419,12 @@
 <link href="#rfc.appendix.A.3" rel="Chapter" title="A.3 Why is there no way to indicate ranges for semantic descriptors?"/>
 
 
-  <meta name="generator" content="xml2rfc version 2.4.3 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.4.8 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Amundsen, M., Richardson, L., and M. Foster" />
   <meta name="dct.identifier" content="urn:ietf:id:draft-amundsen-richardson-foster-alps-00.J" />
-  <meta name="dct.issued" scheme="ISO8601" content="2014-8-10" />
+  <meta name="dct.issued" scheme="ISO8601" content="2015-1-19" />
   <meta name="dct.abstract" content="This document describes ALPS, a data format for defining simple descriptions of application-level semantics, similar in complexity to HTML microformats. An ALPS document can be used as a profile to explain the application semantics of a document with an application-agnostic media type (such as HTML, HAL, Collection+JSON, Siren, etc.). This increases the reusability of profile documents across media types.  " />
   <meta name="description" content="This document describes ALPS, a data format for defining simple descriptions of application-level semantics, similar in complexity to HTML microformats. An ALPS document can be used as a profile to explain the application semantics of a document with an application-agnostic media type (such as HTML, HAL, Collection+JSON, Siren, etc.). This increases the reusability of profile documents across media types.  " />
 
@@ -422,7 +444,7 @@
   <td class="right">CA Technologies, Inc.</td>
 </tr>
 <tr>
-  <td class="left">Expires: February 11, 2015</td>
+  <td class="left">Expires: July 23, 2015</td>
   <td class="right">L. Richardson</td>
 </tr>
 <tr>
@@ -439,7 +461,7 @@
 </tr>
 <tr>
   <td class="left"></td>
-  <td class="right">August 10, 2014</td>
+  <td class="right">January 19, 2015</td>
 </tr>
 
     	
@@ -463,11 +485,11 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on February 11, 2015.</p>
+<p>This Internet-Draft will expire on July 23, 2015.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
-<p>Copyright (c) 2014 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>Copyright (c) 2015 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
@@ -750,7 +772,8 @@
 
 <p> </p>
 <h1 id="rfc.section.2.2.2"><a href="#rfc.section.2.2.2">2.2.2.</a> <a href="#prop-doc" id="prop-doc">'doc'</a></h1>
-<p id="rfc.section.2.2.2.p.1">A text field that contains free-form, usually human-readable, text.  The 'doc' element MAY have two properties: <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> and <a href="#prop-format">'format'</a> <cite title="NONE">[prop-format]</cite>.  If the 'href' property appears it SHOULD contain a dereferencable URL that points to human-readable text. If the 'format' property appears it SHOULD contain one of the following values: </p>
+<p id="rfc.section.2.2.2.p.1">A text field that contains free-form, usually human-readable, text.  </p>
+<p id="rfc.section.2.2.2.p.2">The 'doc' element MAY have two properties: <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> and <a href="#prop-format">'format'</a> <cite title="NONE">[prop-format]</cite>.  If the 'href' property appears it SHOULD contain a dereferencable URL that points to human-readable text. If the 'format' property appears it SHOULD contain one of the following values: </p>
 
 <ol>
   <li>"text"</li>
@@ -758,7 +781,9 @@
   <li>"asciidoc"</li>
 </ol>
 
-<p> Any program processing "doc" elements SHOULD honor the "format" directive and parse/render the content appropriately. If the value in the "format" property is not recognized and/or supported, the processing program MUST treat the content as plain text. If no 'format' property is present, the content SHOULD be treated as plain text.  </p>
+<p> </p>
+<p id="rfc.section.2.2.2.p.3">Any program processing "doc" elements SHOULD honor the "format" directive and parse/render the content appropriately. If the value in the "format" property is not recognized and/or supported, the processing program MUST treat the content as plain text. If no 'format' property is present, the content SHOULD be treated as plain text. Support for additional formats, such as <a href="#draft-ietf-appsawg-text-markdown-05">Markdown</a> <cite title="NONE">[draft-ietf-appsawg-text-markdown-05]</cite>, MAY be considered in the future.  </p>
+<p/>
 
 <dl>
   <dt>XML:</dt>
@@ -768,7 +793,7 @@
 </dl>
 
 <p> </p>
-<p id="rfc.section.2.2.2.p.2">A 'doc' element SHOULD appear as a child of <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>. When present, it describes the meaning and use of the related 'descriptor'.  </p>
+<p id="rfc.section.2.2.2.p.5">A 'doc' element SHOULD appear as a child of <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>. When present, it describes the meaning and use of the related 'descriptor'.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -778,7 +803,7 @@
 </dl>
 
 <p> </p>
-<p id="rfc.section.2.2.2.p.3">The 'doc' element MAY appear as a child of <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite>. When present, it describes the purpose of the ALPS document as a whole.  </p>
+<p id="rfc.section.2.2.2.p.6">The 'doc' element MAY appear as a child of <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite>. When present, it describes the purpose of the ALPS document as a whole.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -855,7 +880,8 @@
 <p> </p>
 <p id="rfc.section.2.2.4.p.6">Since the 'ext' element has no specific meaning within this specification, it MUST be ignored by any application that does not understand its meaning.  </p>
 <h1 id="rfc.section.2.2.5"><a href="#rfc.section.2.2.5">2.2.5.</a> <a href="#prop-format" id="prop-format">'format'</a></h1>
-<p id="rfc.section.2.2.5.p.1">Indicates how the text content should be parsed and/or rendered. This version of the spec identifies three possible values for "format": "text", "html", and "asciidoc." Any other values for this attribute are undefined and SHOULD be treated as plain text. If the program does not recognize the value of the "format" property and/or the "format" property is missing, the content SHOULD be treated as plain text.  This property MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> element.  </p>
+<p id="rfc.section.2.2.5.p.1">Indicates how the text content should be parsed and/or rendered. This version of the spec identifies three possible values for "format": "text", "html", and "asciidoc." Any other values for this attribute are undefined and SHOULD be treated as plain text. If the program does not recognize the value of the "format" property and/or the "format" property is missing, the content SHOULD be treated as plain text. Support for additional formats MAY be considered in the future.  </p>
+<p id="rfc.section.2.2.5.p.2">This property MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> element.  </p>
 <h1 id="rfc.section.2.2.6"><a href="#rfc.section.2.2.6">2.2.6.</a> <a href="#prop-href" id="prop-href">'href'</a></h1>
 <p id="rfc.section.2.2.6.p.1">Contains a resolvable URL.  </p>
 <p id="rfc.section.2.2.6.p.2">When it appears as an attribute of <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>, 'href' points to another 'descriptor' either within the existing ALPS document or in another ALPS document.  </p>
@@ -1199,7 +1225,7 @@
 <p> </p>
 <h1 id="rfc.section.5"><a href="#rfc.section.5">5.</a> <a href="#internationalization" id="internationalization">Internationalization Considerations</a></h1>
 <p id="rfc.section.5.p.1">[TK]</p>
-<p/>
+<p><a id="CREF1" class="info">[CREF1]<span class="info">insert text (consider rfc 5987)</span></a> </p>
 <h1 id="rfc.section.6"><a href="#rfc.section.6">6.</a> Acknowledgements</h1>
 <p id="rfc.section.6.p.1">The following people made contributions to this specification: </p>
 <h1 id="rfc.references"><a href="#rfc.references">7.</a> References</h1>
@@ -1246,6 +1272,12 @@
         <b id="draft-ietf-appsawg-uri-get-off-my-lawn-00">[draft-ietf-appsawg-uri-get-off-my-lawn-00]</b>
       </td>
       <td class="top"><a>Nottingham, M.</a>, "<a>Standardising Structure in URIs</a>", I-D draft-ietf-appsawg-uri-get-off-my-lawn-00, September 2013.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="draft-ietf-appsawg-text-markdown-05">[draft-ietf-appsawg-text-markdown-05]</b>
+      </td>
+      <td class="top"><a>Leonard, S.</a>, "<a>The text/markdown Media Type</a>", I-D draft-ietf-appsawg-text-markdown-05, December 2014.</td>
     </tr>
   </tbody>
 </table>

--- a/draft-00.txt
+++ b/draft-00.txt
@@ -4,11 +4,11 @@
 
 Network Working Group                                        M. Amundsen
 Internet-Draft                                     CA Technologies, Inc.
-Expires: July 23, 2015                                     L. Richardson
+Expires: February 11, 2015                                 L. Richardson
 
                                                                M. Foster
                                                              Fingi, Inc.
-                                                        January 19, 2015
+                                                         August 10, 2014
 
 
                Application-Level Profile Semantics (ALPS)
@@ -44,24 +44,19 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 23, 2015.
-
-
-
-
-
-
-
-
-Amundsen, et al.          Expires July 23, 2015                 [Page 1]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
+   This Internet-Draft will expire on February 11, 2015.
 
 Copyright Notice
 
-   Copyright (c) 2015 IETF Trust and the persons identified as the
+   Copyright (c) 2014 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
+
+
+
+Amundsen, et al.        Expires February 11, 2015               [Page 1]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents
@@ -77,57 +72,57 @@ Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
      1.1.  Notational Conventions  . . . . . . . . . . . . . . . . .   3
-     1.2.  Motivation  . . . . . . . . . . . . . . . . . . . . . . .   4
+     1.2.  Motivation  . . . . . . . . . . . . . . . . . . . . . . .   3
        1.2.1.  Describing Domain-Specific Semantics  . . . . . . . .   4
        1.2.2.  ALPS-based Server Implementations . . . . . . . . . .   4
        1.2.3.  ALPS-based Client Implementations . . . . . . . . . .   4
-     1.3.  A Simple ALPS Example . . . . . . . . . . . . . . . . . .   5
+     1.3.  A Simple ALPS Example . . . . . . . . . . . . . . . . . .   4
      1.4.  Identifying an ALPS Document  . . . . . . . . . . . . . .   9
-   2.  ALPS Documents  . . . . . . . . . . . . . . . . . . . . . . .  10
+   2.  ALPS Documents  . . . . . . . . . . . . . . . . . . . . . . .   9
      2.1.  Compliance  . . . . . . . . . . . . . . . . . . . . . . .  10
      2.2.  ALPS Document Properties  . . . . . . . . . . . . . . . .  10
        2.2.1.  'alps'  . . . . . . . . . . . . . . . . . . . . . . .  10
        2.2.2.  'doc' . . . . . . . . . . . . . . . . . . . . . . . .  10
        2.2.3.  'descriptor'  . . . . . . . . . . . . . . . . . . . .  11
-       2.2.4.  'ext' . . . . . . . . . . . . . . . . . . . . . . . .  13
-       2.2.5.  'format'  . . . . . . . . . . . . . . . . . . . . . .  14
+       2.2.4.  'ext' . . . . . . . . . . . . . . . . . . . . . . . .  12
+       2.2.5.  'format'  . . . . . . . . . . . . . . . . . . . . . .  13
        2.2.6.  'href'  . . . . . . . . . . . . . . . . . . . . . . .  14
        2.2.7.  'id'  . . . . . . . . . . . . . . . . . . . . . . . .  14
        2.2.8.  'link'  . . . . . . . . . . . . . . . . . . . . . . .  16
-       2.2.9.  'name'  . . . . . . . . . . . . . . . . . . . . . . .  17
+       2.2.9.  'name'  . . . . . . . . . . . . . . . . . . . . . . .  16
        2.2.10. 'rel' . . . . . . . . . . . . . . . . . . . . . . . .  17
        2.2.11. 'rt'  . . . . . . . . . . . . . . . . . . . . . . . .  17
        2.2.12. 'type'  . . . . . . . . . . . . . . . . . . . . . . .  17
-       2.2.13. 'value' . . . . . . . . . . . . . . . . . . . . . . .  18
+       2.2.13. 'value' . . . . . . . . . . . . . . . . . . . . . . .  17
        2.2.14. 'version' . . . . . . . . . . . . . . . . . . . . . .  18
      2.3.  ALPS Representations  . . . . . . . . . . . . . . . . . .  18
        2.3.1.  Sample HTML . . . . . . . . . . . . . . . . . . . . .  18
        2.3.2.  XML Representation Example  . . . . . . . . . . . . .  19
-       2.3.3.  JSON Representation Example . . . . . . . . . . . . .  20
-   3.  Applying ALPS documents to Existing Media Types . . . . . . .  22
-     3.1.  Linking to ALPS Documents . . . . . . . . . . . . . . . .  23
+       2.3.3.  JSON Representation Example . . . . . . . . . . . . .  19
+   3.  Applying ALPS documents to Existing Media Types . . . . . . .  21
+     3.1.  Linking to ALPS Documents . . . . . . . . . . . . . . . .  21
+   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  22
+     4.1.  application/alps+xml  . . . . . . . . . . . . . . . . . .  22
+     4.2.  application/alps+json . . . . . . . . . . . . . . . . . .  23
+   5.  Internationalization Considerations . . . . . . . . . . . . .  25
+   6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  25
 
 
 
-Amundsen, et al.          Expires July 23, 2015                 [Page 2]
+Amundsen, et al.        Expires February 11, 2015               [Page 2]
 
-Internet-Draft     Application-Level Profile Semantics      January 2015
+Internet-Draft     Application-Level Profile Semantics       August 2014
 
 
-   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  23
-     4.1.  application/alps+xml  . . . . . . . . . . . . . . . . . .  23
-     4.2.  application/alps+json . . . . . . . . . . . . . . . . . .  25
-   5.  Internationalization Considerations . . . . . . . . . . . . .  26
-   6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  26
-   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  26
-     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  26
-     7.2.  Informative References  . . . . . . . . . . . . . . . . .  26
-   Appendix A.  Frequently Asked Questions . . . . . . . . . . . . .  27
-     A.1.  Why are there no URLs in ALPS?  . . . . . . . . . . . . .  27
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  25
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  25
+     7.2.  Informative References  . . . . . . . . . . . . . . . . .  25
+   Appendix A.  Frequently Asked Questions . . . . . . . . . . . . .  25
+     A.1.  Why are there no URLs in ALPS?  . . . . . . . . . . . . .  25
      A.2.  Why is there no workflow component in the ALPS
-           specification?  . . . . . . . . . . . . . . . . . . . . .  27
+           specification?  . . . . . . . . . . . . . . . . . . . . .  26
      A.3.  Why is there no way to indicate ranges for semantic
-           descriptors?  . . . . . . . . . . . . . . . . . . . . . .  27
+           descriptors?  . . . . . . . . . . . . . . . . . . . . . .  26
 
 1.  Introduction
 
@@ -159,17 +154,6 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
    document are to be interpreted as described in[RFC2119].
 
-
-
-
-
-
-
-Amundsen, et al.          Expires July 23, 2015                 [Page 3]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
 1.2.  Motivation
 
    When implementing a hypermedia client/server application using a
@@ -178,6 +162,14 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    information such as data element names, link relation values, and
    state transfer parameters.  This information is directly related to
    the application being implemented (e.g. accounting, contact
+
+
+
+Amundsen, et al.        Expires February 11, 2015               [Page 3]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
+
    management, etc.) rather than the media type used in the
    representations.
 
@@ -215,26 +207,27 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    changes to the response layout, or even the wholesale replacement of
    one media type with another.
 
-
-
-
-
-
-
-Amundsen, et al.          Expires July 23, 2015                 [Page 4]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
 1.3.  A Simple ALPS Example
 
-   Below is an ALPS document that describes elements of a simple
-   request/response interaction in a contact management application.
-   The profile defines a semantic descriptor called "contact", and three
+   Below is an ALPS document that describes elements of a simple request
+   /response interaction in a contact management application.  The
+   profile defines a semantic descriptor called "contact", and three
    subordinate descriptors ("fullName", "email", and "phone").
 
+
+
+
+
+
+
+
+Amundsen, et al.        Expires February 11, 2015               [Page 4]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
+
    The ALPS document also defines a single, safe state transition, to be
-   represented by a hypermedia control (e.g.  HTML.GET form) with the
+   represented by a hypermedia control (e.g. HTML.GET form) with the
    'id' value of "collection."  This hypermedia control has one input
    value ("nameSearch").  When executed, the response will contain one
    or more "contact" type items.
@@ -274,14 +267,6 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    <html>
      <head>
        <link href="http://alps.io/profiles/contact"
-
-
-
-Amundsen, et al.          Expires July 23, 2015                 [Page 5]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
          rel="profile" />
        <link href="http://alps.io/profiles/contact#contact"
          rel="type" />
@@ -289,6 +274,14 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
      <body>
        <form class="collection"
          method="get"
+
+
+
+Amundsen, et al.        Expires February 11, 2015               [Page 5]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
+
          action="http://example.org/contacts/">
          <label>Name:</label>
          <input name="nameSearch" value="" />
@@ -331,19 +324,19 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
 
                      HTML ALPS Contact Representation
 
-
-
-Amundsen, et al.          Expires July 23, 2015                 [Page 6]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
    HTML representations implement most ALPS elements using HTML's
    "class" attribute.  The "collection" ID has become the CSS class of
    an HTML form's submit button.  The "contact" ID has become the CSS
    class of the TR elements in an HTML table.  The subordinate
    descriptors "fullname","email", and "phone" are rendered as the TD
    elements of each TR.
+
+
+
+Amundsen, et al.        Expires February 11, 2015               [Page 6]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
 
    This HAL document uses the same profile to express the same
    application-level semantics as the HTML document.
@@ -386,14 +379,6 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
        "href" : "http://example.org/contacts/",
 
        "links" : [
-
-
-
-Amundsen, et al.          Expires July 23, 2015                 [Page 7]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
          {
            "rel" : "profile",
            "href" : "http://alps.io/profiles/contacts"
@@ -401,6 +386,14 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
          {
            "rel" : "type",
            "href" : "http://alps.io/profiles/contacts#contact"
+
+
+
+Amundsen, et al.        Expires February 11, 2015               [Page 7]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
+
          }
        ],
 
@@ -442,14 +435,6 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
            "rt" : "contact",
            "data" : [
              {
-
-
-
-Amundsen, et al.          Expires July 23, 2015                 [Page 8]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
                "name" : "fullName",
                "value" : "Zelda Zackney"
              },
@@ -457,6 +442,14 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
                "name" : "email",
                "value" : "zz@example.org"
              },
+
+
+
+Amundsen, et al.        Expires February 11, 2015               [Page 8]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
+
              {
                "name" : "phone",
                "value" : "987.654.3210"
@@ -495,17 +488,6 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    making these ALPS document requests SHOULD honor the server's caching
    directives.
 
-
-
-
-
-
-
-Amundsen, et al.          Expires July 23, 2015                 [Page 9]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
 2.  ALPS Documents
 
    An ALPS document contains a machine-readable collection of
@@ -515,6 +497,14 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    document, their meaning, and their use, independent of how the
    document is represented.  Section 2.3 provides specific details on
    constructing a valid ALPS document in XML and in JSON format.
+
+
+
+
+Amundsen, et al.        Expires February 11, 2015               [Page 9]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
 
 2.1.  Compliance
 
@@ -546,7 +536,6 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
 2.2.2.  'doc'
 
    A text field that contains free-form, usually human-readable, text.
-
    The 'doc' element MAY have two properties: 'href' (Section 2.2.6) and
    'format' (Section 2.2.5).  If the 'href' property appears it SHOULD
    contain a dereferencable URL that points to human-readable text.  If
@@ -554,13 +543,6 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    values:
 
    1.  "text"
-
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 10]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
 
    2.  "html"
 
@@ -571,9 +553,14 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    in the "format" property is not recognized and/or supported, the
    processing program MUST treat the content as plain text.  If no
    'format' property is present, the content SHOULD be treated as plain
-   text.  Support for additional formats, such as Markdown
-   [draft-ietf-appsawg-text-markdown-05], MAY be considered in the
-   future.
+   text.
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 10]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
 
    XML:  <doc format="html"> <h1>Date of Birth</h1> <p>...</p> </doc>
 
@@ -611,13 +598,6 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    Additionally, the 'descriptor' MAY have any of the following
    attributes:
 
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 11]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
    1.  'doc' (Section 2.2.2)
 
    2.  'ext' (Section 2.2.4)
@@ -629,6 +609,14 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    If present, the 'href' property MUST be a dereferenceable URL, that
    points to another 'descriptor' either within the current ALPS
    document or in another ALPS document.
+
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 11]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
 
    If 'descriptor' has an 'href' attribute, then 'descriptor' is
    inheriting all the attributes and sub-properties of the descriptor
@@ -666,17 +654,9 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    2.  An extension link relation type as defined by [RFC5988] whose
        value is the fully-qualified URI of an associated document
        describing the relation type.  This includes URI fragment
-
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 12]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
-       identifiers of ALPS descriptors (e.g.
-       rel="http://alps.io/profiles/item#purchased-by", a URI) per the
-       conventions of Section 2.2.7.2.
+       identifiers of ALPS descriptors (e.g. rel="http://alps.io/
+       profiles/item#purchased-by", a URI) per the conventions of
+       Section 2.2.7.2.
 
    3.  The 'id' property of a state transition descriptor of an
        associated ALPS document (e.g. rel="purchased-by", a short
@@ -684,6 +664,15 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
        Section 2.2.7.3 if the representation includes an ALPS profile.
 
 2.2.4.  'ext'
+
+
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 12]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
 
    The 'ext' element can be used to extend the ALPS document with
    author-specific information.  It provides a way to customize ALPS
@@ -720,21 +709,26 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
 
    2.  'descriptor' (Section 2.2.3)
 
-
-
-
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 13]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
    Since the 'ext' element has no specific meaning within this
    specification, it MUST be ignored by any application that does not
    understand its meaning.
 
 2.2.5.  'format'
+
+
+
+
+
+
+
+
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 13]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
 
    Indicates how the text content should be parsed and/or rendered.
    This version of the spec identifies three possible values for
@@ -742,11 +736,8 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    attribute are undefined and SHOULD be treated as plain text.  If the
    program does not recognize the value of the "format" property and/or
    the "format" property is missing, the content SHOULD be treated as
-   plain text.  Support for additional formats MAY be considered in the
-   future.
-
-   This property MAY appear as an attribute of the 'doc' (Section 2.2.2)
-   element.
+   plain text.  This property MAY appear as an attribute of the 'doc'
+   (Section 2.2.2) element.
 
 2.2.6.  'href'
 
@@ -779,17 +770,21 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    ALPS descriptor with an 'id' of "q" is used to identify an HTML input
    element:
 
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 14]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
    'id' in ALPS...  <descriptor id="q" type="semantic" />
 
    ...becomes the 'class' in HTML  <input class="q" type="text" value=""
       />
+
+
+
+
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 14]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
 
    It should be noted that the exact mapping from ALPS elements (e.g.
    'id') to elements within a particular media type (HTML,
@@ -830,25 +825,22 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
 
               ALPS Description of the same Search Transition
 
-
-
-
-
-
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 15]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
 2.2.7.2.  Fragment Identifiers and 'id'
 
    When applied to an ALPS document, a URI fragment identifier points to
    the 'descriptor' whose 'id' is the value of the fragment.  For
-   example, the fragment identifier "customer" in the URI
-   http://example.com/my-alps-document#customer refers to an ALPS
-   'descriptor' with 'id' set to "customer".
+   example, the fragment identifier "customer" in the URI http://
+   example.com/my-alps-document#customer refers to an ALPS 'descriptor'
+   with 'id' set to "customer".
+
+
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 15]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
 
    A relative URL with a fragment identifier (e.g. "#customer") refers
    to a 'descriptor' within the ALPS document containing the reference.
@@ -888,16 +880,6 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    The 'link' element MUST define the two attributes 'href'
    (Section 2.2.6) and 'rel' (Section 2.2.10).
 
-
-
-
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 16]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
 2.2.9.  'name'
 
    Indicates the name of the 'descriptor' (Section 2.2.3) as found in
@@ -908,6 +890,14 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    (Section 2.2.7) value elsewhere in the ALPS document.  For instance,
    if a single ALPS document defines a semantic descriptor (data
    element) called "customer" and a safe descriptor (transition element)
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 16]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
+
    also called "customer", they cannot both have 'id="customer"' in the
    ALPS document.  One of them needs to have some other 'id', and to set
    'name="customer"'.
@@ -940,30 +930,29 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    each 'descriptor' (Section 2.2.3) element.  The four valid values
    are:
 
-   "semantic"  A state element (e.g.  HTML.SPAN, HTML.INPUT, etc.).
+   "semantic"  A state element (e.g. HTML.SPAN, HTML.INPUT, etc.).
 
    "safe"  A hypermedia control that triggers a safe, idempotent state
-      transition (e.g.  HTTP.GET or HTTP.HEAD).
-
-
-
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 17]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
+      transition (e.g. HTTP.GET or HTTP.HEAD).
 
    "idempotent"  A hypermedia control that triggers an unsafe,
-      idempotent state transition (e.g.  HTTP.PUT or HTTP.DELETE).
+      idempotent state transition (e.g. HTTP.PUT or HTTP.DELETE).
 
    "unsafe"  A hypermedia control that triggers an unsafe, non-
-      idempotent state transition (e.g.  HTTP.POST).
+      idempotent state transition (e.g. HTTP.POST).
 
    If no 'type' attribute is associated with the element, then
    'type="semantic"' is implied.
 
 2.2.13.  'value'
+
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 17]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
 
    Contains a string value.  It MAY appear as an attribute of the 'doc'
    (Section 2.2.2) and the 'ext' (Section 2.2.4) elements.
@@ -989,27 +978,6 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    from the XML and JSON ALPS documents that follow.  Use this HTML
    document as a guide when evaluating the XML and JSON examples.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 18]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
    <!-- sample HTML document -->
    <html>
      <head>
@@ -1029,6 +997,19 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
 
                                 HTML Sample
 
+
+
+
+
+
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 18]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
+
 2.3.2.  XML Representation Example
 
    In the XML version of an ALPS document, the following ALPS properties
@@ -1039,32 +1020,6 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
 2.3.2.1.  Complete XML Representation
 
    Below is an example of an application/alps+xml representation.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 19]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
 
    <?xml version="1.0"?>
    <alps version="1.0">
@@ -1097,6 +1052,20 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
 
    For example:
 
+
+
+
+
+
+
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 19]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
+
    "descriptor" : [
      {
        "id" : "value",
@@ -1111,16 +1080,6 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
 
    The 'doc' (Section 2.2.2) property is always expressed as a named
    object.
-
-
-
-
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 20]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
 
    For example:
 
@@ -1137,46 +1096,6 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
 
    Below is a example of the application/alps+json representation of an
    ALPS document.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 21]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
 
    {
      "alps" : {
@@ -1195,6 +1114,14 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
              {
                "id" : "value",
                "name" : "search",
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 20]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
+
                "type" : "descriptor",
                "doc" : { "value" : "input for search" }
              },
@@ -1224,18 +1151,8 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    as there exists an agreed mapping between ALPS and the target media
    type.  Section 1.3 gave some informative examples of this.
    Normative, up-to-date guidance on applying ALPS documents to existing
-   media types are available at the official ALPS Web site at
-
-
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 22]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
-   (http://alps.io/docs/mapping).  [TK : this page does not yet exist.
-   -mamund]
+   media types are available at the official ALPS Web site at (http://
+   alps.io/docs/mapping).  [TK : this page does not yet exist. -mamund]
 
    Not all media types can faithfully represent all ALPS descriptors.
    For instance, the 'application/json' media type has no standard way
@@ -1253,6 +1170,14 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    representation document has no native ability to link to other
    resources, or no ability to express link relations, the HTTP header
    'Link' [RFC5988] MAY be used to connect the representation document
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 21]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
+
    and the ALPS profile.  If the media type of the representation
    document defines a parameter for linking the document to a profile,
    that parameter MAY be used to connect the representation document and
@@ -1283,32 +1208,34 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
 
    Optional parameters:
 
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 23]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
       charset  This parameter has identical semantics to the charset
-         parameter of the 'application/xml' media type as specified
-         in[RFC3023].
+            parameter of the 'application/xml' media type as specified
+            in[RFC3023].
 
       profile  A whitespace-separated list of IRIs identifying specific
-         constraints or conventions that apply to an ALPS document.  A
-         profile must not change the semantics of the resource
-         representation when processed without profile knowledge, so
-         that clients both with and without knowledge of a profiled
-         resource can safely use the same representation.  The profile
-         parameter may also be used by clients to express their
-         preferences in the content negotiation process.  It is
-         recommended that profile IRIs are dereferenceable and provide
-         useful documentation at that IRI.
+            constraints or conventions that apply to an ALPS document.
+            A profile must not change the semantics of the resource
+            representation when processed without profile knowledge, so
+            that clients both with and without knowledge of a profiled
+            resource can safely use the same representation.  The
+            profile parameter may also be used by clients to express
+            their preferences in the content negotiation process.  It is
+            recommended that profile IRIs are dereferenceable and
+            provide useful documentation at that IRI.
 
    Encoding considerations:
 
+
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 22]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
+
       binary  Same as encoding considerations of application/xml as
-         specified in[RFC3023].
+            specified in[RFC3023].
 
    Security considerations:  This format shares security issues common
       to all XML content types.  It does not provide executable content.
@@ -1335,16 +1262,9 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
 
    person to contact for further information:
 
-      Name:  Mike Amundsen
+      Name: Mike Amundsen
 
       Email:  mca@amundsen.com
-
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 24]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
 
    Intended usage:  Common
 
@@ -1361,15 +1281,23 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
    Optional parameters:
 
       profile  A whitespace-separated list of IRIs identifying specific
-         constraints or conventions that apply to an ALPS document.  A
-         profile must not change the semantics of the resource
-         representation when processed without profile knowledge, so
-         that clients both with and without knowledge of a profiled
-         resource can safely use the same representation.  The profile
-         parameter may also be used by clients to express their
-         preferences in the content negotiation process.  It is
-         recommended that profile IRIs are dereferenceable and provide
-         useful documentation at that IRI.
+            constraints or conventions that apply to an ALPS document.
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 23]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
+
+            A profile must not change the semantics of the resource
+            representation when processed without profile knowledge, so
+            that clients both with and without knowledge of a profiled
+            resource can safely use the same representation.  The
+            profile parameter may also be used by clients to express
+            their preferences in the content negotiation process.  It is
+            recommended that profile IRIs are dereferenceable and
+            provide useful documentation at that IRI.
 
    Encoding considerations:  binary
 
@@ -1395,16 +1323,9 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
 
       object idenfiers:  none
 
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 25]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
    person to contact for further information:
 
-      Name:  Mike Amundsen
+      Name: Mike Amundsen
 
       Email:  mca@amundsen.com
 
@@ -1412,11 +1333,24 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
 
    Author/change controller:  Mike Amundsen
 
+
+
+
+
+
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 24]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
+
 5.  Internationalization Considerations
 
    [TK]
 
-   [[CREF1: insert text (consider rfc 5987)]]
+   [[insert text (consider rfc 5987)]]
 
 6.  Acknowledgements
 
@@ -1446,18 +1380,6 @@ Internet-Draft     Application-Level Profile Semantics      January 2015
               Nottingham, M., "Standardising Structure in URIs", I-D
               draft-ietf-appsawg-uri-get-off-my-lawn-00, September 2013.
 
-   [draft-ietf-appsawg-text-markdown-05]
-              Leonard, S., "The text/markdown Media Type", I-D draft-
-              ietf-appsawg-text-markdown-05, December 2014.
-
-
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 26]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
 Appendix A.  Frequently Asked Questions
 
 A.1.  Why are there no URLs in ALPS?
@@ -1472,6 +1394,14 @@ A.1.  Why are there no URLs in ALPS?
    When implementing ALPS-compliant servers, implementors are free to
    use any URL design they wish.  All that is required is that
    implementors use the same ALPS profile descriptor 'id' and 'name'
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 25]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
+
+
    properties in the representations.  When implementing ALPS-compliant
    client applications, the URLs will be supplied at runtime by the
    server represetentations.  Client apps only need to recognize the
@@ -1505,15 +1435,6 @@ A.3.  Why is there no way to indicate ranges for semantic descriptors?
    service that only supports a single value here and will always supply
    it ("onesie").
 
-
-
-
-
-Amundsen, et al.          Expires July 23, 2015                [Page 27]
-
-Internet-Draft     Application-Level Profile Semantics      January 2015
-
-
    Since ALPS is meant to provide a single description that can be used
    by multiple services, establishing ranges within the ALPS description
    is considered over-constraining service implementations.  Services
@@ -1527,6 +1448,14 @@ Authors' Addresses
 
    EMail: mca@amundsen.com
    URI:   http://amundsen.com
+
+
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 26]
+
+Internet-Draft     Application-Level Profile Semantics       August 2014
 
 
    Leonard Richardson
@@ -1565,4 +1494,19 @@ Authors' Addresses
 
 
 
-Amundsen, et al.          Expires July 23, 2015                [Page 28]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Amundsen, et al.        Expires February 11, 2015              [Page 27]

--- a/draft-00.txt
+++ b/draft-00.txt
@@ -4,11 +4,11 @@
 
 Network Working Group                                        M. Amundsen
 Internet-Draft                                     CA Technologies, Inc.
-Expires: February 11, 2015                                 L. Richardson
+Expires: July 23, 2015                                     L. Richardson
 
                                                                M. Foster
                                                              Fingi, Inc.
-                                                         August 10, 2014
+                                                        January 19, 2015
 
 
                Application-Level Profile Semantics (ALPS)
@@ -44,19 +44,24 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 11, 2015.
+   This Internet-Draft will expire on July 23, 2015.
+
+
+
+
+
+
+
+
+Amundsen, et al.          Expires July 23, 2015                 [Page 1]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
 
 Copyright Notice
 
-   Copyright (c) 2014 IETF Trust and the persons identified as the
+   Copyright (c) 2015 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
-
-
-
-Amundsen, et al.        Expires February 11, 2015               [Page 1]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents
@@ -72,57 +77,57 @@ Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
      1.1.  Notational Conventions  . . . . . . . . . . . . . . . . .   3
-     1.2.  Motivation  . . . . . . . . . . . . . . . . . . . . . . .   3
+     1.2.  Motivation  . . . . . . . . . . . . . . . . . . . . . . .   4
        1.2.1.  Describing Domain-Specific Semantics  . . . . . . . .   4
        1.2.2.  ALPS-based Server Implementations . . . . . . . . . .   4
        1.2.3.  ALPS-based Client Implementations . . . . . . . . . .   4
-     1.3.  A Simple ALPS Example . . . . . . . . . . . . . . . . . .   4
+     1.3.  A Simple ALPS Example . . . . . . . . . . . . . . . . . .   5
      1.4.  Identifying an ALPS Document  . . . . . . . . . . . . . .   9
-   2.  ALPS Documents  . . . . . . . . . . . . . . . . . . . . . . .   9
+   2.  ALPS Documents  . . . . . . . . . . . . . . . . . . . . . . .  10
      2.1.  Compliance  . . . . . . . . . . . . . . . . . . . . . . .  10
      2.2.  ALPS Document Properties  . . . . . . . . . . . . . . . .  10
        2.2.1.  'alps'  . . . . . . . . . . . . . . . . . . . . . . .  10
        2.2.2.  'doc' . . . . . . . . . . . . . . . . . . . . . . . .  10
        2.2.3.  'descriptor'  . . . . . . . . . . . . . . . . . . . .  11
-       2.2.4.  'ext' . . . . . . . . . . . . . . . . . . . . . . . .  12
-       2.2.5.  'format'  . . . . . . . . . . . . . . . . . . . . . .  13
+       2.2.4.  'ext' . . . . . . . . . . . . . . . . . . . . . . . .  13
+       2.2.5.  'format'  . . . . . . . . . . . . . . . . . . . . . .  14
        2.2.6.  'href'  . . . . . . . . . . . . . . . . . . . . . . .  14
        2.2.7.  'id'  . . . . . . . . . . . . . . . . . . . . . . . .  14
        2.2.8.  'link'  . . . . . . . . . . . . . . . . . . . . . . .  16
-       2.2.9.  'name'  . . . . . . . . . . . . . . . . . . . . . . .  16
+       2.2.9.  'name'  . . . . . . . . . . . . . . . . . . . . . . .  17
        2.2.10. 'rel' . . . . . . . . . . . . . . . . . . . . . . . .  17
        2.2.11. 'rt'  . . . . . . . . . . . . . . . . . . . . . . . .  17
        2.2.12. 'type'  . . . . . . . . . . . . . . . . . . . . . . .  17
-       2.2.13. 'value' . . . . . . . . . . . . . . . . . . . . . . .  17
+       2.2.13. 'value' . . . . . . . . . . . . . . . . . . . . . . .  18
        2.2.14. 'version' . . . . . . . . . . . . . . . . . . . . . .  18
      2.3.  ALPS Representations  . . . . . . . . . . . . . . . . . .  18
        2.3.1.  Sample HTML . . . . . . . . . . . . . . . . . . . . .  18
        2.3.2.  XML Representation Example  . . . . . . . . . . . . .  19
-       2.3.3.  JSON Representation Example . . . . . . . . . . . . .  19
-   3.  Applying ALPS documents to Existing Media Types . . . . . . .  21
-     3.1.  Linking to ALPS Documents . . . . . . . . . . . . . . . .  21
-   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  22
-     4.1.  application/alps+xml  . . . . . . . . . . . . . . . . . .  22
-     4.2.  application/alps+json . . . . . . . . . . . . . . . . . .  23
-   5.  Internationalization Considerations . . . . . . . . . . . . .  25
-   6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  25
+       2.3.3.  JSON Representation Example . . . . . . . . . . . . .  20
+   3.  Applying ALPS documents to Existing Media Types . . . . . . .  22
+     3.1.  Linking to ALPS Documents . . . . . . . . . . . . . . . .  23
 
 
 
-Amundsen, et al.        Expires February 11, 2015               [Page 2]
+Amundsen, et al.          Expires July 23, 2015                 [Page 2]
 
-Internet-Draft     Application-Level Profile Semantics       August 2014
+Internet-Draft     Application-Level Profile Semantics      January 2015
 
 
-   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  25
-     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  25
-     7.2.  Informative References  . . . . . . . . . . . . . . . . .  25
-   Appendix A.  Frequently Asked Questions . . . . . . . . . . . . .  25
-     A.1.  Why are there no URLs in ALPS?  . . . . . . . . . . . . .  25
+   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  23
+     4.1.  application/alps+xml  . . . . . . . . . . . . . . . . . .  23
+     4.2.  application/alps+json . . . . . . . . . . . . . . . . . .  25
+   5.  Internationalization Considerations . . . . . . . . . . . . .  26
+   6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  26
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  26
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  26
+     7.2.  Informative References  . . . . . . . . . . . . . . . . .  26
+   Appendix A.  Frequently Asked Questions . . . . . . . . . . . . .  27
+     A.1.  Why are there no URLs in ALPS?  . . . . . . . . . . . . .  27
      A.2.  Why is there no workflow component in the ALPS
-           specification?  . . . . . . . . . . . . . . . . . . . . .  26
+           specification?  . . . . . . . . . . . . . . . . . . . . .  27
      A.3.  Why is there no way to indicate ranges for semantic
-           descriptors?  . . . . . . . . . . . . . . . . . . . . . .  26
+           descriptors?  . . . . . . . . . . . . . . . . . . . . . .  27
 
 1.  Introduction
 
@@ -154,6 +159,17 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
    document are to be interpreted as described in[RFC2119].
 
+
+
+
+
+
+
+Amundsen, et al.          Expires July 23, 2015                 [Page 3]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
 1.2.  Motivation
 
    When implementing a hypermedia client/server application using a
@@ -162,14 +178,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    information such as data element names, link relation values, and
    state transfer parameters.  This information is directly related to
    the application being implemented (e.g. accounting, contact
-
-
-
-Amundsen, et al.        Expires February 11, 2015               [Page 3]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
    management, etc.) rather than the media type used in the
    representations.
 
@@ -207,27 +215,26 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    changes to the response layout, or even the wholesale replacement of
    one media type with another.
 
+
+
+
+
+
+
+Amundsen, et al.          Expires July 23, 2015                 [Page 4]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
 1.3.  A Simple ALPS Example
 
-   Below is an ALPS document that describes elements of a simple request
-   /response interaction in a contact management application.  The
-   profile defines a semantic descriptor called "contact", and three
+   Below is an ALPS document that describes elements of a simple
+   request/response interaction in a contact management application.
+   The profile defines a semantic descriptor called "contact", and three
    subordinate descriptors ("fullName", "email", and "phone").
 
-
-
-
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015               [Page 4]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
    The ALPS document also defines a single, safe state transition, to be
-   represented by a hypermedia control (e.g. HTML.GET form) with the
+   represented by a hypermedia control (e.g.  HTML.GET form) with the
    'id' value of "collection."  This hypermedia control has one input
    value ("nameSearch").  When executed, the response will contain one
    or more "contact" type items.
@@ -267,6 +274,14 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    <html>
      <head>
        <link href="http://alps.io/profiles/contact"
+
+
+
+Amundsen, et al.          Expires July 23, 2015                 [Page 5]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
          rel="profile" />
        <link href="http://alps.io/profiles/contact#contact"
          rel="type" />
@@ -274,14 +289,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
      <body>
        <form class="collection"
          method="get"
-
-
-
-Amundsen, et al.        Expires February 11, 2015               [Page 5]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
          action="http://example.org/contacts/">
          <label>Name:</label>
          <input name="nameSearch" value="" />
@@ -324,19 +331,19 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
                      HTML ALPS Contact Representation
 
+
+
+Amundsen, et al.          Expires July 23, 2015                 [Page 6]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
    HTML representations implement most ALPS elements using HTML's
    "class" attribute.  The "collection" ID has become the CSS class of
    an HTML form's submit button.  The "contact" ID has become the CSS
    class of the TR elements in an HTML table.  The subordinate
    descriptors "fullname","email", and "phone" are rendered as the TD
    elements of each TR.
-
-
-
-Amundsen, et al.        Expires February 11, 2015               [Page 6]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
 
    This HAL document uses the same profile to express the same
    application-level semantics as the HTML document.
@@ -379,6 +386,14 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
        "href" : "http://example.org/contacts/",
 
        "links" : [
+
+
+
+Amundsen, et al.          Expires July 23, 2015                 [Page 7]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
          {
            "rel" : "profile",
            "href" : "http://alps.io/profiles/contacts"
@@ -386,14 +401,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
          {
            "rel" : "type",
            "href" : "http://alps.io/profiles/contacts#contact"
-
-
-
-Amundsen, et al.        Expires February 11, 2015               [Page 7]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
          }
        ],
 
@@ -435,6 +442,14 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
            "rt" : "contact",
            "data" : [
              {
+
+
+
+Amundsen, et al.          Expires July 23, 2015                 [Page 8]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
                "name" : "fullName",
                "value" : "Zelda Zackney"
              },
@@ -442,14 +457,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
                "name" : "email",
                "value" : "zz@example.org"
              },
-
-
-
-Amundsen, et al.        Expires February 11, 2015               [Page 8]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
              {
                "name" : "phone",
                "value" : "987.654.3210"
@@ -488,6 +495,17 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    making these ALPS document requests SHOULD honor the server's caching
    directives.
 
+
+
+
+
+
+
+Amundsen, et al.          Expires July 23, 2015                 [Page 9]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
 2.  ALPS Documents
 
    An ALPS document contains a machine-readable collection of
@@ -497,14 +515,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    document, their meaning, and their use, independent of how the
    document is represented.  Section 2.3 provides specific details on
    constructing a valid ALPS document in XML and in JSON format.
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015               [Page 9]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
 
 2.1.  Compliance
 
@@ -536,6 +546,7 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 2.2.2.  'doc'
 
    A text field that contains free-form, usually human-readable, text.
+
    The 'doc' element MAY have two properties: 'href' (Section 2.2.6) and
    'format' (Section 2.2.5).  If the 'href' property appears it SHOULD
    contain a dereferencable URL that points to human-readable text.  If
@@ -543,6 +554,13 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    values:
 
    1.  "text"
+
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 10]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
 
    2.  "html"
 
@@ -553,14 +571,9 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    in the "format" property is not recognized and/or supported, the
    processing program MUST treat the content as plain text.  If no
    'format' property is present, the content SHOULD be treated as plain
-   text.
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 10]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
+   text.  Support for additional formats, such as Markdown
+   [draft-ietf-appsawg-text-markdown-05], MAY be considered in the
+   future.
 
    XML:  <doc format="html"> <h1>Date of Birth</h1> <p>...</p> </doc>
 
@@ -598,6 +611,13 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    Additionally, the 'descriptor' MAY have any of the following
    attributes:
 
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 11]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
    1.  'doc' (Section 2.2.2)
 
    2.  'ext' (Section 2.2.4)
@@ -609,14 +629,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    If present, the 'href' property MUST be a dereferenceable URL, that
    points to another 'descriptor' either within the current ALPS
    document or in another ALPS document.
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 11]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
 
    If 'descriptor' has an 'href' attribute, then 'descriptor' is
    inheriting all the attributes and sub-properties of the descriptor
@@ -654,9 +666,17 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    2.  An extension link relation type as defined by [RFC5988] whose
        value is the fully-qualified URI of an associated document
        describing the relation type.  This includes URI fragment
-       identifiers of ALPS descriptors (e.g. rel="http://alps.io/
-       profiles/item#purchased-by", a URI) per the conventions of
-       Section 2.2.7.2.
+
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 12]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
+       identifiers of ALPS descriptors (e.g.
+       rel="http://alps.io/profiles/item#purchased-by", a URI) per the
+       conventions of Section 2.2.7.2.
 
    3.  The 'id' property of a state transition descriptor of an
        associated ALPS document (e.g. rel="purchased-by", a short
@@ -664,15 +684,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
        Section 2.2.7.3 if the representation includes an ALPS profile.
 
 2.2.4.  'ext'
-
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 12]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
 
    The 'ext' element can be used to extend the ALPS document with
    author-specific information.  It provides a way to customize ALPS
@@ -709,26 +720,21 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
    2.  'descriptor' (Section 2.2.3)
 
+
+
+
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 13]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
    Since the 'ext' element has no specific meaning within this
    specification, it MUST be ignored by any application that does not
    understand its meaning.
 
 2.2.5.  'format'
-
-
-
-
-
-
-
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 13]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
 
    Indicates how the text content should be parsed and/or rendered.
    This version of the spec identifies three possible values for
@@ -736,8 +742,11 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    attribute are undefined and SHOULD be treated as plain text.  If the
    program does not recognize the value of the "format" property and/or
    the "format" property is missing, the content SHOULD be treated as
-   plain text.  This property MAY appear as an attribute of the 'doc'
-   (Section 2.2.2) element.
+   plain text.  Support for additional formats MAY be considered in the
+   future.
+
+   This property MAY appear as an attribute of the 'doc' (Section 2.2.2)
+   element.
 
 2.2.6.  'href'
 
@@ -770,21 +779,17 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    ALPS descriptor with an 'id' of "q" is used to identify an HTML input
    element:
 
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 14]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
    'id' in ALPS...  <descriptor id="q" type="semantic" />
 
    ...becomes the 'class' in HTML  <input class="q" type="text" value=""
       />
-
-
-
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 14]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
 
    It should be noted that the exact mapping from ALPS elements (e.g.
    'id') to elements within a particular media type (HTML,
@@ -825,22 +830,25 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
               ALPS Description of the same Search Transition
 
+
+
+
+
+
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 15]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
 2.2.7.2.  Fragment Identifiers and 'id'
 
    When applied to an ALPS document, a URI fragment identifier points to
    the 'descriptor' whose 'id' is the value of the fragment.  For
-   example, the fragment identifier "customer" in the URI http://
-   example.com/my-alps-document#customer refers to an ALPS 'descriptor'
-   with 'id' set to "customer".
-
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 15]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
+   example, the fragment identifier "customer" in the URI
+   http://example.com/my-alps-document#customer refers to an ALPS
+   'descriptor' with 'id' set to "customer".
 
    A relative URL with a fragment identifier (e.g. "#customer") refers
    to a 'descriptor' within the ALPS document containing the reference.
@@ -880,6 +888,16 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    The 'link' element MUST define the two attributes 'href'
    (Section 2.2.6) and 'rel' (Section 2.2.10).
 
+
+
+
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 16]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
 2.2.9.  'name'
 
    Indicates the name of the 'descriptor' (Section 2.2.3) as found in
@@ -890,14 +908,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    (Section 2.2.7) value elsewhere in the ALPS document.  For instance,
    if a single ALPS document defines a semantic descriptor (data
    element) called "customer" and a safe descriptor (transition element)
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 16]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
    also called "customer", they cannot both have 'id="customer"' in the
    ALPS document.  One of them needs to have some other 'id', and to set
    'name="customer"'.
@@ -930,29 +940,30 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    each 'descriptor' (Section 2.2.3) element.  The four valid values
    are:
 
-   "semantic"  A state element (e.g. HTML.SPAN, HTML.INPUT, etc.).
+   "semantic"  A state element (e.g.  HTML.SPAN, HTML.INPUT, etc.).
 
    "safe"  A hypermedia control that triggers a safe, idempotent state
-      transition (e.g. HTTP.GET or HTTP.HEAD).
+      transition (e.g.  HTTP.GET or HTTP.HEAD).
+
+
+
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 17]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
 
    "idempotent"  A hypermedia control that triggers an unsafe,
-      idempotent state transition (e.g. HTTP.PUT or HTTP.DELETE).
+      idempotent state transition (e.g.  HTTP.PUT or HTTP.DELETE).
 
    "unsafe"  A hypermedia control that triggers an unsafe, non-
-      idempotent state transition (e.g. HTTP.POST).
+      idempotent state transition (e.g.  HTTP.POST).
 
    If no 'type' attribute is associated with the element, then
    'type="semantic"' is implied.
 
 2.2.13.  'value'
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 17]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
 
    Contains a string value.  It MAY appear as an attribute of the 'doc'
    (Section 2.2.2) and the 'ext' (Section 2.2.4) elements.
@@ -978,6 +989,27 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    from the XML and JSON ALPS documents that follow.  Use this HTML
    document as a guide when evaluating the XML and JSON examples.
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 18]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
    <!-- sample HTML document -->
    <html>
      <head>
@@ -997,19 +1029,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
                                 HTML Sample
 
-
-
-
-
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 18]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
 2.3.2.  XML Representation Example
 
    In the XML version of an ALPS document, the following ALPS properties
@@ -1020,6 +1039,32 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 2.3.2.1.  Complete XML Representation
 
    Below is an example of an application/alps+xml representation.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 19]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
 
    <?xml version="1.0"?>
    <alps version="1.0">
@@ -1052,20 +1097,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
    For example:
 
-
-
-
-
-
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 19]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
    "descriptor" : [
      {
        "id" : "value",
@@ -1080,6 +1111,16 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
    The 'doc' (Section 2.2.2) property is always expressed as a named
    object.
+
+
+
+
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 20]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
 
    For example:
 
@@ -1096,6 +1137,46 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
    Below is a example of the application/alps+json representation of an
    ALPS document.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 21]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
 
    {
      "alps" : {
@@ -1114,14 +1195,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
              {
                "id" : "value",
                "name" : "search",
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 20]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
                "type" : "descriptor",
                "doc" : { "value" : "input for search" }
              },
@@ -1151,8 +1224,18 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    as there exists an agreed mapping between ALPS and the target media
    type.  Section 1.3 gave some informative examples of this.
    Normative, up-to-date guidance on applying ALPS documents to existing
-   media types are available at the official ALPS Web site at (http://
-   alps.io/docs/mapping).  [TK : this page does not yet exist. -mamund]
+   media types are available at the official ALPS Web site at
+
+
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 22]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
+   (http://alps.io/docs/mapping).  [TK : this page does not yet exist.
+   -mamund]
 
    Not all media types can faithfully represent all ALPS descriptors.
    For instance, the 'application/json' media type has no standard way
@@ -1170,14 +1253,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    representation document has no native ability to link to other
    resources, or no ability to express link relations, the HTTP header
    'Link' [RFC5988] MAY be used to connect the representation document
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 21]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
    and the ALPS profile.  If the media type of the representation
    document defines a parameter for linking the document to a profile,
    that parameter MAY be used to connect the representation document and
@@ -1208,34 +1283,32 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
    Optional parameters:
 
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 23]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
       charset  This parameter has identical semantics to the charset
-            parameter of the 'application/xml' media type as specified
-            in[RFC3023].
+         parameter of the 'application/xml' media type as specified
+         in[RFC3023].
 
       profile  A whitespace-separated list of IRIs identifying specific
-            constraints or conventions that apply to an ALPS document.
-            A profile must not change the semantics of the resource
-            representation when processed without profile knowledge, so
-            that clients both with and without knowledge of a profiled
-            resource can safely use the same representation.  The
-            profile parameter may also be used by clients to express
-            their preferences in the content negotiation process.  It is
-            recommended that profile IRIs are dereferenceable and
-            provide useful documentation at that IRI.
+         constraints or conventions that apply to an ALPS document.  A
+         profile must not change the semantics of the resource
+         representation when processed without profile knowledge, so
+         that clients both with and without knowledge of a profiled
+         resource can safely use the same representation.  The profile
+         parameter may also be used by clients to express their
+         preferences in the content negotiation process.  It is
+         recommended that profile IRIs are dereferenceable and provide
+         useful documentation at that IRI.
 
    Encoding considerations:
 
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 22]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
       binary  Same as encoding considerations of application/xml as
-            specified in[RFC3023].
+         specified in[RFC3023].
 
    Security considerations:  This format shares security issues common
       to all XML content types.  It does not provide executable content.
@@ -1262,9 +1335,16 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
    person to contact for further information:
 
-      Name: Mike Amundsen
+      Name:  Mike Amundsen
 
       Email:  mca@amundsen.com
+
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 24]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
 
    Intended usage:  Common
 
@@ -1281,23 +1361,15 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    Optional parameters:
 
       profile  A whitespace-separated list of IRIs identifying specific
-            constraints or conventions that apply to an ALPS document.
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 23]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
-            A profile must not change the semantics of the resource
-            representation when processed without profile knowledge, so
-            that clients both with and without knowledge of a profiled
-            resource can safely use the same representation.  The
-            profile parameter may also be used by clients to express
-            their preferences in the content negotiation process.  It is
-            recommended that profile IRIs are dereferenceable and
-            provide useful documentation at that IRI.
+         constraints or conventions that apply to an ALPS document.  A
+         profile must not change the semantics of the resource
+         representation when processed without profile knowledge, so
+         that clients both with and without knowledge of a profiled
+         resource can safely use the same representation.  The profile
+         parameter may also be used by clients to express their
+         preferences in the content negotiation process.  It is
+         recommended that profile IRIs are dereferenceable and provide
+         useful documentation at that IRI.
 
    Encoding considerations:  binary
 
@@ -1323,9 +1395,16 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
       object idenfiers:  none
 
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 25]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
    person to contact for further information:
 
-      Name: Mike Amundsen
+      Name:  Mike Amundsen
 
       Email:  mca@amundsen.com
 
@@ -1333,24 +1412,11 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
    Author/change controller:  Mike Amundsen
 
-
-
-
-
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 24]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
 5.  Internationalization Considerations
 
    [TK]
 
-   [[insert text (consider rfc 5987)]]
+   [[CREF1: insert text (consider rfc 5987)]]
 
 6.  Acknowledgements
 
@@ -1380,6 +1446,18 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
               Nottingham, M., "Standardising Structure in URIs", I-D
               draft-ietf-appsawg-uri-get-off-my-lawn-00, September 2013.
 
+   [draft-ietf-appsawg-text-markdown-05]
+              Leonard, S., "The text/markdown Media Type", I-D draft-
+              ietf-appsawg-text-markdown-05, December 2014.
+
+
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 26]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
 Appendix A.  Frequently Asked Questions
 
 A.1.  Why are there no URLs in ALPS?
@@ -1394,14 +1472,6 @@ A.1.  Why are there no URLs in ALPS?
    When implementing ALPS-compliant servers, implementors are free to
    use any URL design they wish.  All that is required is that
    implementors use the same ALPS profile descriptor 'id' and 'name'
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 25]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
    properties in the representations.  When implementing ALPS-compliant
    client applications, the URLs will be supplied at runtime by the
    server represetentations.  Client apps only need to recognize the
@@ -1435,6 +1505,15 @@ A.3.  Why is there no way to indicate ranges for semantic descriptors?
    service that only supports a single value here and will always supply
    it ("onesie").
 
+
+
+
+
+Amundsen, et al.          Expires July 23, 2015                [Page 27]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
    Since ALPS is meant to provide a single description that can be used
    by multiple services, establishing ranges within the ALPS description
    is considered over-constraining service implementations.  Services
@@ -1448,14 +1527,6 @@ Authors' Addresses
 
    EMail: mca@amundsen.com
    URI:   http://amundsen.com
-
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 26]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
 
 
    Leonard Richardson
@@ -1494,19 +1565,4 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 27]
+Amundsen, et al.          Expires July 23, 2015                [Page 28]

--- a/draft-00.txt
+++ b/draft-00.txt
@@ -4,11 +4,11 @@
 
 Network Working Group                                        M. Amundsen
 Internet-Draft                                     CA Technologies, Inc.
-Expires: February 11, 2015                                 L. Richardson
+Expires: July 24, 2015                                     L. Richardson
 
                                                                M. Foster
                                                              Fingi, Inc.
-                                                         August 10, 2014
+                                                        January 20, 2015
 
 
                Application-Level Profile Semantics (ALPS)
@@ -44,19 +44,24 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on February 11, 2015.
+   This Internet-Draft will expire on July 24, 2015.
+
+
+
+
+
+
+
+
+Amundsen, et al.          Expires July 24, 2015                 [Page 1]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
 
 Copyright Notice
 
-   Copyright (c) 2014 IETF Trust and the persons identified as the
+   Copyright (c) 2015 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
-
-
-
-Amundsen, et al.        Expires February 11, 2015               [Page 1]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents
@@ -72,19 +77,19 @@ Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
      1.1.  Notational Conventions  . . . . . . . . . . . . . . . . .   3
-     1.2.  Motivation  . . . . . . . . . . . . . . . . . . . . . . .   3
+     1.2.  Motivation  . . . . . . . . . . . . . . . . . . . . . . .   4
        1.2.1.  Describing Domain-Specific Semantics  . . . . . . . .   4
        1.2.2.  ALPS-based Server Implementations . . . . . . . . . .   4
        1.2.3.  ALPS-based Client Implementations . . . . . . . . . .   4
-     1.3.  A Simple ALPS Example . . . . . . . . . . . . . . . . . .   4
+     1.3.  A Simple ALPS Example . . . . . . . . . . . . . . . . . .   5
      1.4.  Identifying an ALPS Document  . . . . . . . . . . . . . .   9
-   2.  ALPS Documents  . . . . . . . . . . . . . . . . . . . . . . .   9
+   2.  ALPS Documents  . . . . . . . . . . . . . . . . . . . . . . .  10
      2.1.  Compliance  . . . . . . . . . . . . . . . . . . . . . . .  10
      2.2.  ALPS Document Properties  . . . . . . . . . . . . . . . .  10
        2.2.1.  'alps'  . . . . . . . . . . . . . . . . . . . . . . .  10
        2.2.2.  'doc' . . . . . . . . . . . . . . . . . . . . . . . .  10
        2.2.3.  'descriptor'  . . . . . . . . . . . . . . . . . . . .  11
-       2.2.4.  'ext' . . . . . . . . . . . . . . . . . . . . . . . .  12
+       2.2.4.  'ext' . . . . . . . . . . . . . . . . . . . . . . . .  13
        2.2.5.  'format'  . . . . . . . . . . . . . . . . . . . . . .  13
        2.2.6.  'href'  . . . . . . . . . . . . . . . . . . . . . . .  14
        2.2.7.  'id'  . . . . . . . . . . . . . . . . . . . . . . . .  14
@@ -93,32 +98,32 @@ Table of Contents
        2.2.10. 'rel' . . . . . . . . . . . . . . . . . . . . . . . .  17
        2.2.11. 'rt'  . . . . . . . . . . . . . . . . . . . . . . . .  17
        2.2.12. 'type'  . . . . . . . . . . . . . . . . . . . . . . .  17
-       2.2.13. 'value' . . . . . . . . . . . . . . . . . . . . . . .  17
+       2.2.13. 'value' . . . . . . . . . . . . . . . . . . . . . . .  18
        2.2.14. 'version' . . . . . . . . . . . . . . . . . . . . . .  18
      2.3.  ALPS Representations  . . . . . . . . . . . . . . . . . .  18
        2.3.1.  Sample HTML . . . . . . . . . . . . . . . . . . . . .  18
        2.3.2.  XML Representation Example  . . . . . . . . . . . . .  19
        2.3.3.  JSON Representation Example . . . . . . . . . . . . .  19
    3.  Applying ALPS documents to Existing Media Types . . . . . . .  21
-     3.1.  Linking to ALPS Documents . . . . . . . . . . . . . . . .  21
+     3.1.  Linking to ALPS Documents . . . . . . . . . . . . . . . .  22
+
+
+
+Amundsen, et al.          Expires July 24, 2015                 [Page 2]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
    4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  22
      4.1.  application/alps+xml  . . . . . . . . . . . . . . . . . .  22
-     4.2.  application/alps+json . . . . . . . . . . . . . . . . . .  23
+     4.2.  application/alps+json . . . . . . . . . . . . . . . . . .  24
    5.  Internationalization Considerations . . . . . . . . . . . . .  25
    6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  25
-
-
-
-Amundsen, et al.        Expires February 11, 2015               [Page 2]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
    7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  25
      7.1.  Normative References  . . . . . . . . . . . . . . . . . .  25
      7.2.  Informative References  . . . . . . . . . . . . . . . . .  25
-   Appendix A.  Frequently Asked Questions . . . . . . . . . . . . .  25
-     A.1.  Why are there no URLs in ALPS?  . . . . . . . . . . . . .  25
+   Appendix A.  Frequently Asked Questions . . . . . . . . . . . . .  26
+     A.1.  Why are there no URLs in ALPS?  . . . . . . . . . . . . .  26
      A.2.  Why is there no workflow component in the ALPS
            specification?  . . . . . . . . . . . . . . . . . . . . .  26
      A.3.  Why is there no way to indicate ranges for semantic
@@ -154,6 +159,17 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
    document are to be interpreted as described in[RFC2119].
 
+
+
+
+
+
+
+Amundsen, et al.          Expires July 24, 2015                 [Page 3]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
 1.2.  Motivation
 
    When implementing a hypermedia client/server application using a
@@ -162,14 +178,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    information such as data element names, link relation values, and
    state transfer parameters.  This information is directly related to
    the application being implemented (e.g. accounting, contact
-
-
-
-Amundsen, et al.        Expires February 11, 2015               [Page 3]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
    management, etc.) rather than the media type used in the
    representations.
 
@@ -207,27 +215,26 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    changes to the response layout, or even the wholesale replacement of
    one media type with another.
 
+
+
+
+
+
+
+Amundsen, et al.          Expires July 24, 2015                 [Page 4]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
 1.3.  A Simple ALPS Example
 
-   Below is an ALPS document that describes elements of a simple request
-   /response interaction in a contact management application.  The
-   profile defines a semantic descriptor called "contact", and three
+   Below is an ALPS document that describes elements of a simple
+   request/response interaction in a contact management application.
+   The profile defines a semantic descriptor called "contact", and three
    subordinate descriptors ("fullName", "email", and "phone").
 
-
-
-
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015               [Page 4]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
    The ALPS document also defines a single, safe state transition, to be
-   represented by a hypermedia control (e.g. HTML.GET form) with the
+   represented by a hypermedia control (e.g.  HTML.GET form) with the
    'id' value of "collection."  This hypermedia control has one input
    value ("nameSearch").  When executed, the response will contain one
    or more "contact" type items.
@@ -267,6 +274,14 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    <html>
      <head>
        <link href="http://alps.io/profiles/contact"
+
+
+
+Amundsen, et al.          Expires July 24, 2015                 [Page 5]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
          rel="profile" />
        <link href="http://alps.io/profiles/contact#contact"
          rel="type" />
@@ -274,14 +289,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
      <body>
        <form class="collection"
          method="get"
-
-
-
-Amundsen, et al.        Expires February 11, 2015               [Page 5]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
          action="http://example.org/contacts/">
          <label>Name:</label>
          <input name="nameSearch" value="" />
@@ -324,19 +331,19 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
                      HTML ALPS Contact Representation
 
+
+
+Amundsen, et al.          Expires July 24, 2015                 [Page 6]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
    HTML representations implement most ALPS elements using HTML's
    "class" attribute.  The "collection" ID has become the CSS class of
    an HTML form's submit button.  The "contact" ID has become the CSS
    class of the TR elements in an HTML table.  The subordinate
    descriptors "fullname","email", and "phone" are rendered as the TD
    elements of each TR.
-
-
-
-Amundsen, et al.        Expires February 11, 2015               [Page 6]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
 
    This HAL document uses the same profile to express the same
    application-level semantics as the HTML document.
@@ -379,6 +386,14 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
        "href" : "http://example.org/contacts/",
 
        "links" : [
+
+
+
+Amundsen, et al.          Expires July 24, 2015                 [Page 7]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
          {
            "rel" : "profile",
            "href" : "http://alps.io/profiles/contacts"
@@ -386,14 +401,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
          {
            "rel" : "type",
            "href" : "http://alps.io/profiles/contacts#contact"
-
-
-
-Amundsen, et al.        Expires February 11, 2015               [Page 7]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
          }
        ],
 
@@ -435,6 +442,14 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
            "rt" : "contact",
            "data" : [
              {
+
+
+
+Amundsen, et al.          Expires July 24, 2015                 [Page 8]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
                "name" : "fullName",
                "value" : "Zelda Zackney"
              },
@@ -442,14 +457,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
                "name" : "email",
                "value" : "zz@example.org"
              },
-
-
-
-Amundsen, et al.        Expires February 11, 2015               [Page 8]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
              {
                "name" : "phone",
                "value" : "987.654.3210"
@@ -488,6 +495,17 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    making these ALPS document requests SHOULD honor the server's caching
    directives.
 
+
+
+
+
+
+
+Amundsen, et al.          Expires July 24, 2015                 [Page 9]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
 2.  ALPS Documents
 
    An ALPS document contains a machine-readable collection of
@@ -497,14 +515,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    document, their meaning, and their use, independent of how the
    document is represented.  Section 2.3 provides specific details on
    constructing a valid ALPS document in XML and in JSON format.
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015               [Page 9]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
 
 2.1.  Compliance
 
@@ -540,27 +550,20 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    'format' (Section 2.2.5).  If the 'href' property appears it SHOULD
    contain a dereferencable URL that points to human-readable text.  If
    the 'format' property appears it SHOULD contain one of the following
-   values:
-
-   1.  "text"
-
-   2.  "html"
-
-   3.  "asciidoc"
-
-   Any program processing "doc" elements SHOULD honor the "format"
-   directive and parse/render the content appropriately.  If the value
-   in the "format" property is not recognized and/or supported, the
-   processing program MUST treat the content as plain text.  If no
-   'format' property is present, the content SHOULD be treated as plain
-   text.
+   values: "text", "html", "asciidoc", or "markdown".  Any program
+   processing "doc" elements SHOULD honor the "format" directive and
+   parse/render the content appropriately.  If the value in the "format"
+   property is not recognized and/or supported, the processing program
 
 
 
-Amundsen, et al.        Expires February 11, 2015              [Page 10]
+Amundsen, et al.          Expires July 24, 2015                [Page 10]
 
-Internet-Draft     Application-Level Profile Semantics       August 2014
+Internet-Draft     Application-Level Profile Semantics      January 2015
 
+
+   MUST treat the content as plain text.  If no 'format' property is
+   present, the content SHOULD be treated as plain text.
 
    XML:  <doc format="html"> <h1>Date of Birth</h1> <p>...</p> </doc>
 
@@ -606,17 +609,18 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
    4.  'type' (Section 2.2.12)
 
+
+
+
+
+Amundsen, et al.          Expires July 24, 2015                [Page 11]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
    If present, the 'href' property MUST be a dereferenceable URL, that
    points to another 'descriptor' either within the current ALPS
    document or in another ALPS document.
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 11]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
 
    If 'descriptor' has an 'href' attribute, then 'descriptor' is
    inheriting all the attributes and sub-properties of the descriptor
@@ -654,25 +658,23 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    2.  An extension link relation type as defined by [RFC5988] whose
        value is the fully-qualified URI of an associated document
        describing the relation type.  This includes URI fragment
-       identifiers of ALPS descriptors (e.g. rel="http://alps.io/
-       profiles/item#purchased-by", a URI) per the conventions of
-       Section 2.2.7.2.
+       identifiers of ALPS descriptors (e.g.
+       rel="http://alps.io/profiles/item#purchased-by", a URI) per the
+       conventions of Section 2.2.7.2.
 
    3.  The 'id' property of a state transition descriptor of an
        associated ALPS document (e.g. rel="purchased-by", a short
        string) per the conventions of section Section 2.2.7.1 and
        Section 2.2.7.3 if the representation includes an ALPS profile.
 
-2.2.4.  'ext'
 
 
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 12]
+Amundsen, et al.          Expires July 24, 2015                [Page 12]
 
-Internet-Draft     Application-Level Profile Semantics       August 2014
+Internet-Draft     Application-Level Profile Semantics      January 2015
 
+
+2.2.4.  'ext'
 
    The 'ext' element can be used to extend the ALPS document with
    author-specific information.  It provides a way to customize ALPS
@@ -715,29 +717,33 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
 2.2.5.  'format'
 
-
-
-
-
-
-
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 13]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
    Indicates how the text content should be parsed and/or rendered.
-   This version of the spec identifies three possible values for
-   "format": "text", "html", and "asciidoc."  Any other values for this
-   attribute are undefined and SHOULD be treated as plain text.  If the
-   program does not recognize the value of the "format" property and/or
-   the "format" property is missing, the content SHOULD be treated as
-   plain text.  This property MAY appear as an attribute of the 'doc'
-   (Section 2.2.2) element.
+   This specification identifies a range of possible values for
+   "format":
+
+   o  "text", for plain text, MUST be supported.
+
+
+
+Amundsen, et al.          Expires July 24, 2015                [Page 13]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
+   o  "html", for HTML, SHOULD be supported.
+
+   o  "asciidoc", for AsciiDoc, MAY be supported.
+
+   o  "markdown", per The text/markdown Media Type
+      [draft-ietf-appsawg-text-markdown-05], MAY be supported.
+
+   Any other values for this attribute are undefined and SHOULD be
+   treated as plain text.  If the program does not recognize the value
+   of the "format" property and/or the "format" property is missing, the
+   content SHOULD be treated as plain text.
+
+   This property MAY appear as an attribute of the 'doc' (Section 2.2.2)
+   element.
 
 2.2.6.  'href'
 
@@ -772,19 +778,16 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
    'id' in ALPS...  <descriptor id="q" type="semantic" />
 
+
+
+
+Amundsen, et al.          Expires July 24, 2015                [Page 14]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
    ...becomes the 'class' in HTML  <input class="q" type="text" value=""
       />
-
-
-
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 14]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
 
    It should be noted that the exact mapping from ALPS elements (e.g.
    'id') to elements within a particular media type (HTML,
@@ -829,18 +832,18 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
    When applied to an ALPS document, a URI fragment identifier points to
    the 'descriptor' whose 'id' is the value of the fragment.  For
-   example, the fragment identifier "customer" in the URI http://
-   example.com/my-alps-document#customer refers to an ALPS 'descriptor'
-   with 'id' set to "customer".
+   example, the fragment identifier "customer" in the URI
 
 
 
 
-
-Amundsen, et al.        Expires February 11, 2015              [Page 15]
+Amundsen, et al.          Expires July 24, 2015                [Page 15]
 
-Internet-Draft     Application-Level Profile Semantics       August 2014
+Internet-Draft     Application-Level Profile Semantics      January 2015
 
+
+   http://example.com/my-alps-document#customer refers to an ALPS
+   'descriptor' with 'id' set to "customer".
 
    A relative URL with a fragment identifier (e.g. "#customer") refers
    to a 'descriptor' within the ALPS document containing the reference.
@@ -886,18 +889,19 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    generic representations.  It MAY appear as a property of
    'descriptor'.
 
+
+
+
+
+Amundsen, et al.          Expires July 24, 2015                [Page 16]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
    This is used when the name of the 'descriptor' is used as an 'id'
    (Section 2.2.7) value elsewhere in the ALPS document.  For instance,
    if a single ALPS document defines a semantic descriptor (data
    element) called "customer" and a safe descriptor (transition element)
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 16]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
    also called "customer", they cannot both have 'id="customer"' in the
    ALPS document.  One of them needs to have some other 'id', and to set
    'name="customer"'.
@@ -930,29 +934,30 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    each 'descriptor' (Section 2.2.3) element.  The four valid values
    are:
 
-   "semantic"  A state element (e.g. HTML.SPAN, HTML.INPUT, etc.).
+   "semantic"  A state element (e.g.  HTML.SPAN, HTML.INPUT, etc.).
 
    "safe"  A hypermedia control that triggers a safe, idempotent state
-      transition (e.g. HTTP.GET or HTTP.HEAD).
+      transition (e.g.  HTTP.GET or HTTP.HEAD).
 
    "idempotent"  A hypermedia control that triggers an unsafe,
-      idempotent state transition (e.g. HTTP.PUT or HTTP.DELETE).
+      idempotent state transition (e.g.  HTTP.PUT or HTTP.DELETE).
 
    "unsafe"  A hypermedia control that triggers an unsafe, non-
-      idempotent state transition (e.g. HTTP.POST).
+      idempotent state transition (e.g.  HTTP.POST).
+
+
+
+
+
+Amundsen, et al.          Expires July 24, 2015                [Page 17]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
 
    If no 'type' attribute is associated with the element, then
    'type="semantic"' is implied.
 
 2.2.13.  'value'
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 17]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
 
    Contains a string value.  It MAY appear as an attribute of the 'doc'
    (Section 2.2.2) and the 'ext' (Section 2.2.4) elements.
@@ -1000,14 +1005,9 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
 
 
-
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 18]
+Amundsen, et al.          Expires July 24, 2015                [Page 18]
 
-Internet-Draft     Application-Level Profile Semantics       August 2014
+Internet-Draft     Application-Level Profile Semantics      January 2015
 
 
 2.3.2.  XML Representation Example
@@ -1050,7 +1050,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    expressed as arrays of anonymous objects - even when there is only
    one member in the array.
 
-   For example:
 
 
 
@@ -1061,10 +1060,13 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
 
 
-Amundsen, et al.        Expires February 11, 2015              [Page 19]
+
+Amundsen, et al.          Expires July 24, 2015                [Page 19]
 
-Internet-Draft     Application-Level Profile Semantics       August 2014
+Internet-Draft     Application-Level Profile Semantics      January 2015
 
+
+   For example:
 
    "descriptor" : [
      {
@@ -1097,6 +1099,29 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    Below is a example of the application/alps+json representation of an
    ALPS document.
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Amundsen, et al.          Expires July 24, 2015                [Page 20]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
    {
      "alps" : {
        "version" : "1.0",
@@ -1114,14 +1139,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
              {
                "id" : "value",
                "name" : "search",
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 20]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
                "type" : "descriptor",
                "doc" : { "value" : "input for search" }
              },
@@ -1151,8 +1168,18 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    as there exists an agreed mapping between ALPS and the target media
    type.  Section 1.3 gave some informative examples of this.
    Normative, up-to-date guidance on applying ALPS documents to existing
-   media types are available at the official ALPS Web site at (http://
-   alps.io/docs/mapping).  [TK : this page does not yet exist. -mamund]
+   media types are available at the official ALPS Web site at
+
+
+
+
+Amundsen, et al.          Expires July 24, 2015                [Page 21]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
+   (http://alps.io/docs/mapping).  [TK : this page does not yet exist.
+   -mamund]
 
    Not all media types can faithfully represent all ALPS descriptors.
    For instance, the 'application/json' media type has no standard way
@@ -1170,14 +1197,6 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    representation document has no native ability to link to other
    resources, or no ability to express link relations, the HTTP header
    'Link' [RFC5988] MAY be used to connect the representation document
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 21]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
    and the ALPS profile.  If the media type of the representation
    document defines a parameter for linking the document to a profile,
    that parameter MAY be used to connect the representation document and
@@ -1208,34 +1227,32 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
    Optional parameters:
 
+
+
+Amundsen, et al.          Expires July 24, 2015                [Page 22]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
       charset  This parameter has identical semantics to the charset
-            parameter of the 'application/xml' media type as specified
-            in[RFC3023].
+         parameter of the 'application/xml' media type as specified
+         in[RFC3023].
 
       profile  A whitespace-separated list of IRIs identifying specific
-            constraints or conventions that apply to an ALPS document.
-            A profile must not change the semantics of the resource
-            representation when processed without profile knowledge, so
-            that clients both with and without knowledge of a profiled
-            resource can safely use the same representation.  The
-            profile parameter may also be used by clients to express
-            their preferences in the content negotiation process.  It is
-            recommended that profile IRIs are dereferenceable and
-            provide useful documentation at that IRI.
+         constraints or conventions that apply to an ALPS document.  A
+         profile must not change the semantics of the resource
+         representation when processed without profile knowledge, so
+         that clients both with and without knowledge of a profiled
+         resource can safely use the same representation.  The profile
+         parameter may also be used by clients to express their
+         preferences in the content negotiation process.  It is
+         recommended that profile IRIs are dereferenceable and provide
+         useful documentation at that IRI.
 
    Encoding considerations:
 
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 22]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
       binary  Same as encoding considerations of application/xml as
-            specified in[RFC3023].
+         specified in[RFC3023].
 
    Security considerations:  This format shares security issues common
       to all XML content types.  It does not provide executable content.
@@ -1262,9 +1279,16 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
    person to contact for further information:
 
-      Name: Mike Amundsen
+      Name:  Mike Amundsen
 
       Email:  mca@amundsen.com
+
+
+
+Amundsen, et al.          Expires July 24, 2015                [Page 23]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
 
    Intended usage:  Common
 
@@ -1281,23 +1305,15 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
    Optional parameters:
 
       profile  A whitespace-separated list of IRIs identifying specific
-            constraints or conventions that apply to an ALPS document.
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 23]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
-            A profile must not change the semantics of the resource
-            representation when processed without profile knowledge, so
-            that clients both with and without knowledge of a profiled
-            resource can safely use the same representation.  The
-            profile parameter may also be used by clients to express
-            their preferences in the content negotiation process.  It is
-            recommended that profile IRIs are dereferenceable and
-            provide useful documentation at that IRI.
+         constraints or conventions that apply to an ALPS document.  A
+         profile must not change the semantics of the resource
+         representation when processed without profile knowledge, so
+         that clients both with and without knowledge of a profiled
+         resource can safely use the same representation.  The profile
+         parameter may also be used by clients to express their
+         preferences in the content negotiation process.  It is
+         recommended that profile IRIs are dereferenceable and provide
+         useful documentation at that IRI.
 
    Encoding considerations:  binary
 
@@ -1323,9 +1339,16 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
       object idenfiers:  none
 
+
+
+Amundsen, et al.          Expires July 24, 2015                [Page 24]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
    person to contact for further information:
 
-      Name: Mike Amundsen
+      Name:  Mike Amundsen
 
       Email:  mca@amundsen.com
 
@@ -1333,24 +1356,11 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
    Author/change controller:  Mike Amundsen
 
-
-
-
-
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 24]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
 5.  Internationalization Considerations
 
    [TK]
 
-   [[insert text (consider rfc 5987)]]
+   [[CREF1: insert text (consider rfc 5987)]]
 
 6.  Acknowledgements
 
@@ -1380,6 +1390,18 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
               Nottingham, M., "Standardising Structure in URIs", I-D
               draft-ietf-appsawg-uri-get-off-my-lawn-00, September 2013.
 
+   [draft-ietf-appsawg-text-markdown-05]
+              Leonard, S., "The text/markdown Media Type", I-D draft-
+              ietf-appsawg-text-markdown-05, December 2014.
+
+
+
+
+Amundsen, et al.          Expires July 24, 2015                [Page 25]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
 Appendix A.  Frequently Asked Questions
 
 A.1.  Why are there no URLs in ALPS?
@@ -1394,14 +1416,6 @@ A.1.  Why are there no URLs in ALPS?
    When implementing ALPS-compliant servers, implementors are free to
    use any URL design they wish.  All that is required is that
    implementors use the same ALPS profile descriptor 'id' and 'name'
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 25]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
-
-
    properties in the representations.  When implementing ALPS-compliant
    client applications, the URLs will be supplied at runtime by the
    server represetentations.  Client apps only need to recognize the
@@ -1435,6 +1449,15 @@ A.3.  Why is there no way to indicate ranges for semantic descriptors?
    service that only supports a single value here and will always supply
    it ("onesie").
 
+
+
+
+
+Amundsen, et al.          Expires July 24, 2015                [Page 26]
+
+Internet-Draft     Application-Level Profile Semantics      January 2015
+
+
    Since ALPS is meant to provide a single description that can be used
    by multiple services, establishing ranges within the ALPS description
    is considered over-constraining service implementations.  Services
@@ -1448,14 +1471,6 @@ Authors' Addresses
 
    EMail: mca@amundsen.com
    URI:   http://amundsen.com
-
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 26]
-
-Internet-Draft     Application-Level Profile Semantics       August 2014
 
 
    Leonard Richardson
@@ -1494,19 +1509,4 @@ Internet-Draft     Application-Level Profile Semantics       August 2014
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Amundsen, et al.        Expires February 11, 2015              [Page 27]
+Amundsen, et al.          Expires July 24, 2015                [Page 27]

--- a/draft-00.xml
+++ b/draft-00.xml
@@ -484,8 +484,6 @@
           <t>
             A text field that contains free-form, usually
             human-readable, text.
-          </t>
-          <t>
             The 'doc' element MAY have two properties:
             <xref target="prop-href">'href'</xref>
             and
@@ -499,19 +497,13 @@
               <t>"html"</t>
               <t>"asciidoc"</t>
             </list>
-          </t>
-          <t>
             Any program processing "doc" elements SHOULD honor the
             "format" directive and parse/render the content
             appropriately. If the value in the "format" property is
             not recognized and/or supported, the processing program
             MUST treat the content as plain text. If no 'format' property is
             present, the content SHOULD be treated as plain
-            text. Support for additional formats, such as
-            <xref target="draft-ietf-appsawg-text-markdown-05">Markdown</xref>,
-            MAY be considered in the future.
-          </t>
-          <t>
+            text.
             <list style="hanging">
               <t hangText="XML:"><![CDATA[
 <doc format="html">
@@ -747,10 +739,7 @@
             undefined and SHOULD be treated as plain text. If the
             program does not recognize the value of the "format"
             property and/or the "format" property is missing, the
-            content SHOULD be treated as plain text. Support for
-            additional formats MAY be considered in the future.
-          </t>
-          <t>
+            content SHOULD be treated as plain text.
             This property MAY appear as an attribute of the
             <xref target="prop-doc">'doc'</xref>
             element.
@@ -1517,16 +1506,6 @@
         </front>
         <seriesInfo name="I-D" value="draft-ietf-appsawg-uri-get-off-my-lawn-00"/>
         <format type="HTML" target="http://tools.ietf.org/html/draft-ietf-appsawg-uri-get-off-my-lawn-00"/>
-      </reference>
-      <reference anchor="draft-ietf-appsawg-text-markdown-05">
-        <front>
-          <title>The text/markdown Media Type</title>
-          <author initials="S." surname="Leonard" fullname="Sean Leonard">
-          </author>
-          <date month="December" year="2014"/>
-        </front>
-        <seriesInfo name="I-D" value="draft-ietf-appsawg-text-markdown-05"/>
-        <format type="HTML" target="https://tools.ietf.org/html/draft-ietf-appsawg-text-markdown-05"/>
       </reference>
     </references>
     <section title="Frequently Asked Questions">

--- a/draft-00.xml
+++ b/draft-00.xml
@@ -488,22 +488,16 @@
             <xref target="prop-href">'href'</xref>
             and
             <xref target="prop-format">'format'</xref>.
-            If the 'href' property appears it SHOULD contain
-            a dereferencable URL that points to human-readable
-            text. If the 'format' property appears it SHOULD
-            contain one of the following values:
-            <list style="numbers">
-              <t>"text"</t>
-              <t>"html"</t>
-              <t>"asciidoc"</t>
-            </list>
+            If the 'href' property appears it SHOULD contain a
+            dereferencable URL that points to human-readable text. If
+            the 'format' property appears it SHOULD contain one of the
+            following values: "text", "html", "asciidoc", or "markdown".
             Any program processing "doc" elements SHOULD honor the
             "format" directive and parse/render the content
-            appropriately. If the value in the "format" property is
-            not recognized and/or supported, the processing program
-            MUST treat the content as plain text. If no 'format' property is
-            present, the content SHOULD be treated as plain
-            text.
+            appropriately. If the value in the "format" property is not
+            recognized and/or supported, the processing program MUST
+            treat the content as plain text. If no 'format' property is
+            present, the content SHOULD be treated as plain text.
             <list style="hanging">
               <t hangText="XML:"><![CDATA[
 <doc format="html">
@@ -733,16 +727,25 @@
         <section anchor="prop-format" title="'format'">
           <t>
             Indicates how the text content should be parsed and/or
-            rendered. This version of the spec identifies three
-            possible values for "format": "text", "html", and
-            "asciidoc." Any other values for this attribute are
-            undefined and SHOULD be treated as plain text. If the
-            program does not recognize the value of the "format"
-            property and/or the "format" property is missing, the
-            content SHOULD be treated as plain text.
+            rendered. This specification identifies a range of possible
+            values for "format":
+            <list style="symbols">
+              <t>"text", for plain text, MUST be supported.</t>
+              <t>"html", for HTML, SHOULD be supported.</t>
+              <t>"asciidoc", for AsciiDoc, MAY be supported.</t>
+              <t>"markdown", per
+              <xref target="draft-ietf-appsawg-text-markdown-05">The text/markdown Media Type</xref>,
+              MAY be supported.</t>
+            </list>
+            Any other values for this attribute are undefined and SHOULD
+            be treated as plain text. If the program does not recognize
+            the value of the "format" property and/or the "format"
+            property is missing, the content SHOULD be treated as plain
+            text.
+          </t>
+          <t>
             This property MAY appear as an attribute of the
-            <xref target="prop-doc">'doc'</xref>
-            element.
+            <xref target="prop-doc">'doc'</xref> element.
           </t>
         </section>
         <section anchor="prop-href" title="'href'">
@@ -1506,6 +1509,16 @@
         </front>
         <seriesInfo name="I-D" value="draft-ietf-appsawg-uri-get-off-my-lawn-00"/>
         <format type="HTML" target="http://tools.ietf.org/html/draft-ietf-appsawg-uri-get-off-my-lawn-00"/>
+      </reference>
+      <reference anchor="draft-ietf-appsawg-text-markdown-05">
+        <front>
+          <title>The text/markdown Media Type</title>
+          <author initials="S." surname="Leonard" fullname="Sean Leonard">
+          </author>
+          <date month="December" year="2014"/>
+        </front>
+        <seriesInfo name="I-D" value="draft-ietf-appsawg-text-markdown-05"/>
+        <format type="HTML" target="http://tools.ietf.org/html/draft-ietf-appsawg-text-markdown-05"/>
       </reference>
     </references>
     <section title="Frequently Asked Questions">

--- a/draft-00.xml
+++ b/draft-00.xml
@@ -484,6 +484,8 @@
           <t>
             A text field that contains free-form, usually
             human-readable, text.
+          </t>
+          <t>
             The 'doc' element MAY have two properties:
             <xref target="prop-href">'href'</xref>
             and
@@ -497,13 +499,19 @@
               <t>"html"</t>
               <t>"asciidoc"</t>
             </list>
+          </t>
+          <t>
             Any program processing "doc" elements SHOULD honor the
             "format" directive and parse/render the content
             appropriately. If the value in the "format" property is
             not recognized and/or supported, the processing program
             MUST treat the content as plain text. If no 'format' property is
             present, the content SHOULD be treated as plain
-            text.
+            text. Support for additional formats, such as
+            <xref target="draft-ietf-appsawg-text-markdown-05">Markdown</xref>,
+            MAY be considered in the future.
+          </t>
+          <t>
             <list style="hanging">
               <t hangText="XML:"><![CDATA[
 <doc format="html">
@@ -739,7 +747,10 @@
             undefined and SHOULD be treated as plain text. If the
             program does not recognize the value of the "format"
             property and/or the "format" property is missing, the
-            content SHOULD be treated as plain text.
+            content SHOULD be treated as plain text. Support for
+            additional formats MAY be considered in the future.
+          </t>
+          <t>
             This property MAY appear as an attribute of the
             <xref target="prop-doc">'doc'</xref>
             element.
@@ -1506,6 +1517,16 @@
         </front>
         <seriesInfo name="I-D" value="draft-ietf-appsawg-uri-get-off-my-lawn-00"/>
         <format type="HTML" target="http://tools.ietf.org/html/draft-ietf-appsawg-uri-get-off-my-lawn-00"/>
+      </reference>
+      <reference anchor="draft-ietf-appsawg-text-markdown-05">
+        <front>
+          <title>The text/markdown Media Type</title>
+          <author initials="S." surname="Leonard" fullname="Sean Leonard">
+          </author>
+          <date month="December" year="2014"/>
+        </front>
+        <seriesInfo name="I-D" value="draft-ietf-appsawg-text-markdown-05"/>
+        <format type="HTML" target="https://tools.ietf.org/html/draft-ietf-appsawg-text-markdown-05"/>
       </reference>
     </references>
     <section title="Frequently Asked Questions">

--- a/index.html
+++ b/index.html
@@ -12,6 +12,28 @@
 	  a {
 	  text-decoration: none;
 	  }
+      /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+      a.info {
+          /* This is the key. */
+          position: relative;
+          z-index: 24;
+          text-decoration: none;
+      }
+      a.info:hover {
+          z-index: 25;
+          color: #FFF; background-color: #900;
+      }
+      a.info span { display: none; }
+      a.info:hover span.info {
+          /* The span will display just on :hover state. */
+          display: block;
+          position: absolute;
+          font-size: smaller;
+          top: 2em; left: -5em; width: 15em;
+          padding: 2px; border: 1px solid #333;
+          color: #900; background-color: #EEE;
+          text-align: left;
+      }
 	  a.smpl {
 	  color: black;
 	  }
@@ -397,12 +419,12 @@
 <link href="#rfc.appendix.A.3" rel="Chapter" title="A.3 Why is there no way to indicate ranges for semantic descriptors?"/>
 
 
-  <meta name="generator" content="xml2rfc version 2.4.3 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.4.8 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Amundsen, M., Richardson, L., and M. Foster" />
   <meta name="dct.identifier" content="urn:ietf:id:draft-amundsen-richardson-foster-alps-00.J" />
-  <meta name="dct.issued" scheme="ISO8601" content="2014-8-10" />
+  <meta name="dct.issued" scheme="ISO8601" content="2015-1-20" />
   <meta name="dct.abstract" content="This document describes ALPS, a data format for defining simple descriptions of application-level semantics, similar in complexity to HTML microformats. An ALPS document can be used as a profile to explain the application semantics of a document with an application-agnostic media type (such as HTML, HAL, Collection+JSON, Siren, etc.). This increases the reusability of profile documents across media types.  " />
   <meta name="description" content="This document describes ALPS, a data format for defining simple descriptions of application-level semantics, similar in complexity to HTML microformats. An ALPS document can be used as a profile to explain the application semantics of a document with an application-agnostic media type (such as HTML, HAL, Collection+JSON, Siren, etc.). This increases the reusability of profile documents across media types.  " />
 
@@ -422,7 +444,7 @@
   <td class="right">CA Technologies, Inc.</td>
 </tr>
 <tr>
-  <td class="left">Expires: February 11, 2015</td>
+  <td class="left">Expires: July 24, 2015</td>
   <td class="right">L. Richardson</td>
 </tr>
 <tr>
@@ -439,7 +461,7 @@
 </tr>
 <tr>
   <td class="left"></td>
-  <td class="right">August 10, 2014</td>
+  <td class="right">January 20, 2015</td>
 </tr>
 
     	
@@ -463,11 +485,11 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on February 11, 2015.</p>
+<p>This Internet-Draft will expire on July 24, 2015.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
-<p>Copyright (c) 2014 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>Copyright (c) 2015 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
@@ -750,15 +772,7 @@
 
 <p> </p>
 <h1 id="rfc.section.2.2.2"><a href="#rfc.section.2.2.2">2.2.2.</a> <a href="#prop-doc" id="prop-doc">'doc'</a></h1>
-<p id="rfc.section.2.2.2.p.1">A text field that contains free-form, usually human-readable, text.  The 'doc' element MAY have two properties: <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> and <a href="#prop-format">'format'</a> <cite title="NONE">[prop-format]</cite>.  If the 'href' property appears it SHOULD contain a dereferencable URL that points to human-readable text. If the 'format' property appears it SHOULD contain one of the following values: </p>
-
-<ol>
-  <li>"text"</li>
-  <li>"html"</li>
-  <li>"asciidoc"</li>
-</ol>
-
-<p> Any program processing "doc" elements SHOULD honor the "format" directive and parse/render the content appropriately. If the value in the "format" property is not recognized and/or supported, the processing program MUST treat the content as plain text. If no 'format' property is present, the content SHOULD be treated as plain text.  </p>
+<p id="rfc.section.2.2.2.p.1">A text field that contains free-form, usually human-readable, text.  The 'doc' element MAY have two properties: <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> and <a href="#prop-format">'format'</a> <cite title="NONE">[prop-format]</cite>.  If the 'href' property appears it SHOULD contain a dereferencable URL that points to human-readable text. If the 'format' property appears it SHOULD contain one of the following values: "text", "html", "asciidoc", or "markdown".  Any program processing "doc" elements SHOULD honor the "format" directive and parse/render the content appropriately. If the value in the "format" property is not recognized and/or supported, the processing program MUST treat the content as plain text. If no 'format' property is present, the content SHOULD be treated as plain text.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -855,7 +869,17 @@
 <p> </p>
 <p id="rfc.section.2.2.4.p.6">Since the 'ext' element has no specific meaning within this specification, it MUST be ignored by any application that does not understand its meaning.  </p>
 <h1 id="rfc.section.2.2.5"><a href="#rfc.section.2.2.5">2.2.5.</a> <a href="#prop-format" id="prop-format">'format'</a></h1>
-<p id="rfc.section.2.2.5.p.1">Indicates how the text content should be parsed and/or rendered. This version of the spec identifies three possible values for "format": "text", "html", and "asciidoc." Any other values for this attribute are undefined and SHOULD be treated as plain text. If the program does not recognize the value of the "format" property and/or the "format" property is missing, the content SHOULD be treated as plain text.  This property MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> element.  </p>
+<p id="rfc.section.2.2.5.p.1">Indicates how the text content should be parsed and/or rendered. This specification identifies a range of possible values for "format": </p>
+
+<ul>
+  <li>"text", for plain text, MUST be supported.</li>
+  <li>"html", for HTML, SHOULD be supported.</li>
+  <li>"asciidoc", for AsciiDoc, MAY be supported.</li>
+  <li>"markdown", per <a href="#draft-ietf-appsawg-text-markdown-05">The text/markdown Media Type</a> <cite title="NONE">[draft-ietf-appsawg-text-markdown-05]</cite>, MAY be supported.</li>
+</ul>
+
+<p> Any other values for this attribute are undefined and SHOULD be treated as plain text. If the program does not recognize the value of the "format" property and/or the "format" property is missing, the content SHOULD be treated as plain text.  </p>
+<p id="rfc.section.2.2.5.p.2">This property MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> element.  </p>
 <h1 id="rfc.section.2.2.6"><a href="#rfc.section.2.2.6">2.2.6.</a> <a href="#prop-href" id="prop-href">'href'</a></h1>
 <p id="rfc.section.2.2.6.p.1">Contains a resolvable URL.  </p>
 <p id="rfc.section.2.2.6.p.2">When it appears as an attribute of <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>, 'href' points to another 'descriptor' either within the existing ALPS document or in another ALPS document.  </p>
@@ -1199,7 +1223,7 @@
 <p> </p>
 <h1 id="rfc.section.5"><a href="#rfc.section.5">5.</a> <a href="#internationalization" id="internationalization">Internationalization Considerations</a></h1>
 <p id="rfc.section.5.p.1">[TK]</p>
-<p/>
+<p><a id="CREF1" class="info">[CREF1]<span class="info">insert text (consider rfc 5987)</span></a> </p>
 <h1 id="rfc.section.6"><a href="#rfc.section.6">6.</a> Acknowledgements</h1>
 <p id="rfc.section.6.p.1">The following people made contributions to this specification: </p>
 <h1 id="rfc.references"><a href="#rfc.references">7.</a> References</h1>
@@ -1246,6 +1270,12 @@
         <b id="draft-ietf-appsawg-uri-get-off-my-lawn-00">[draft-ietf-appsawg-uri-get-off-my-lawn-00]</b>
       </td>
       <td class="top"><a>Nottingham, M.</a>, "<a>Standardising Structure in URIs</a>", I-D draft-ietf-appsawg-uri-get-off-my-lawn-00, September 2013.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="draft-ietf-appsawg-text-markdown-05">[draft-ietf-appsawg-text-markdown-05]</b>
+      </td>
+      <td class="top"><a>Leonard, S.</a>, "<a>The text/markdown Media Type</a>", I-D draft-ietf-appsawg-text-markdown-05, December 2014.</td>
     </tr>
   </tbody>
 </table>

--- a/index.html
+++ b/index.html
@@ -12,28 +12,6 @@
 	  a {
 	  text-decoration: none;
 	  }
-      /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
-      a.info {
-          /* This is the key. */
-          position: relative;
-          z-index: 24;
-          text-decoration: none;
-      }
-      a.info:hover {
-          z-index: 25;
-          color: #FFF; background-color: #900;
-      }
-      a.info span { display: none; }
-      a.info:hover span.info {
-          /* The span will display just on :hover state. */
-          display: block;
-          position: absolute;
-          font-size: smaller;
-          top: 2em; left: -5em; width: 15em;
-          padding: 2px; border: 1px solid #333;
-          color: #900; background-color: #EEE;
-          text-align: left;
-      }
 	  a.smpl {
 	  color: black;
 	  }
@@ -419,12 +397,12 @@
 <link href="#rfc.appendix.A.3" rel="Chapter" title="A.3 Why is there no way to indicate ranges for semantic descriptors?"/>
 
 
-  <meta name="generator" content="xml2rfc version 2.4.8 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.4.3 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Amundsen, M., Richardson, L., and M. Foster" />
   <meta name="dct.identifier" content="urn:ietf:id:draft-amundsen-richardson-foster-alps-00.J" />
-  <meta name="dct.issued" scheme="ISO8601" content="2015-1-19" />
+  <meta name="dct.issued" scheme="ISO8601" content="2014-8-10" />
   <meta name="dct.abstract" content="This document describes ALPS, a data format for defining simple descriptions of application-level semantics, similar in complexity to HTML microformats. An ALPS document can be used as a profile to explain the application semantics of a document with an application-agnostic media type (such as HTML, HAL, Collection+JSON, Siren, etc.). This increases the reusability of profile documents across media types.  " />
   <meta name="description" content="This document describes ALPS, a data format for defining simple descriptions of application-level semantics, similar in complexity to HTML microformats. An ALPS document can be used as a profile to explain the application semantics of a document with an application-agnostic media type (such as HTML, HAL, Collection+JSON, Siren, etc.). This increases the reusability of profile documents across media types.  " />
 
@@ -444,7 +422,7 @@
   <td class="right">CA Technologies, Inc.</td>
 </tr>
 <tr>
-  <td class="left">Expires: July 23, 2015</td>
+  <td class="left">Expires: February 11, 2015</td>
   <td class="right">L. Richardson</td>
 </tr>
 <tr>
@@ -461,7 +439,7 @@
 </tr>
 <tr>
   <td class="left"></td>
-  <td class="right">January 19, 2015</td>
+  <td class="right">August 10, 2014</td>
 </tr>
 
     	
@@ -485,11 +463,11 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on July 23, 2015.</p>
+<p>This Internet-Draft will expire on February 11, 2015.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
-<p>Copyright (c) 2015 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>Copyright (c) 2014 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
@@ -772,8 +750,7 @@
 
 <p> </p>
 <h1 id="rfc.section.2.2.2"><a href="#rfc.section.2.2.2">2.2.2.</a> <a href="#prop-doc" id="prop-doc">'doc'</a></h1>
-<p id="rfc.section.2.2.2.p.1">A text field that contains free-form, usually human-readable, text.  </p>
-<p id="rfc.section.2.2.2.p.2">The 'doc' element MAY have two properties: <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> and <a href="#prop-format">'format'</a> <cite title="NONE">[prop-format]</cite>.  If the 'href' property appears it SHOULD contain a dereferencable URL that points to human-readable text. If the 'format' property appears it SHOULD contain one of the following values: </p>
+<p id="rfc.section.2.2.2.p.1">A text field that contains free-form, usually human-readable, text.  The 'doc' element MAY have two properties: <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> and <a href="#prop-format">'format'</a> <cite title="NONE">[prop-format]</cite>.  If the 'href' property appears it SHOULD contain a dereferencable URL that points to human-readable text. If the 'format' property appears it SHOULD contain one of the following values: </p>
 
 <ol>
   <li>"text"</li>
@@ -781,9 +758,7 @@
   <li>"asciidoc"</li>
 </ol>
 
-<p> </p>
-<p id="rfc.section.2.2.2.p.3">Any program processing "doc" elements SHOULD honor the "format" directive and parse/render the content appropriately. If the value in the "format" property is not recognized and/or supported, the processing program MUST treat the content as plain text. If no 'format' property is present, the content SHOULD be treated as plain text. Support for additional formats, such as <a href="#draft-ietf-appsawg-text-markdown-05">Markdown</a> <cite title="NONE">[draft-ietf-appsawg-text-markdown-05]</cite>, MAY be considered in the future.  </p>
-<p/>
+<p> Any program processing "doc" elements SHOULD honor the "format" directive and parse/render the content appropriately. If the value in the "format" property is not recognized and/or supported, the processing program MUST treat the content as plain text. If no 'format' property is present, the content SHOULD be treated as plain text.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -793,7 +768,7 @@
 </dl>
 
 <p> </p>
-<p id="rfc.section.2.2.2.p.5">A 'doc' element SHOULD appear as a child of <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>. When present, it describes the meaning and use of the related 'descriptor'.  </p>
+<p id="rfc.section.2.2.2.p.2">A 'doc' element SHOULD appear as a child of <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>. When present, it describes the meaning and use of the related 'descriptor'.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -803,7 +778,7 @@
 </dl>
 
 <p> </p>
-<p id="rfc.section.2.2.2.p.6">The 'doc' element MAY appear as a child of <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite>. When present, it describes the purpose of the ALPS document as a whole.  </p>
+<p id="rfc.section.2.2.2.p.3">The 'doc' element MAY appear as a child of <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite>. When present, it describes the purpose of the ALPS document as a whole.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -880,8 +855,7 @@
 <p> </p>
 <p id="rfc.section.2.2.4.p.6">Since the 'ext' element has no specific meaning within this specification, it MUST be ignored by any application that does not understand its meaning.  </p>
 <h1 id="rfc.section.2.2.5"><a href="#rfc.section.2.2.5">2.2.5.</a> <a href="#prop-format" id="prop-format">'format'</a></h1>
-<p id="rfc.section.2.2.5.p.1">Indicates how the text content should be parsed and/or rendered. This version of the spec identifies three possible values for "format": "text", "html", and "asciidoc." Any other values for this attribute are undefined and SHOULD be treated as plain text. If the program does not recognize the value of the "format" property and/or the "format" property is missing, the content SHOULD be treated as plain text. Support for additional formats MAY be considered in the future.  </p>
-<p id="rfc.section.2.2.5.p.2">This property MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> element.  </p>
+<p id="rfc.section.2.2.5.p.1">Indicates how the text content should be parsed and/or rendered. This version of the spec identifies three possible values for "format": "text", "html", and "asciidoc." Any other values for this attribute are undefined and SHOULD be treated as plain text. If the program does not recognize the value of the "format" property and/or the "format" property is missing, the content SHOULD be treated as plain text.  This property MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> element.  </p>
 <h1 id="rfc.section.2.2.6"><a href="#rfc.section.2.2.6">2.2.6.</a> <a href="#prop-href" id="prop-href">'href'</a></h1>
 <p id="rfc.section.2.2.6.p.1">Contains a resolvable URL.  </p>
 <p id="rfc.section.2.2.6.p.2">When it appears as an attribute of <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>, 'href' points to another 'descriptor' either within the existing ALPS document or in another ALPS document.  </p>
@@ -1225,7 +1199,7 @@
 <p> </p>
 <h1 id="rfc.section.5"><a href="#rfc.section.5">5.</a> <a href="#internationalization" id="internationalization">Internationalization Considerations</a></h1>
 <p id="rfc.section.5.p.1">[TK]</p>
-<p><a id="CREF1" class="info">[CREF1]<span class="info">insert text (consider rfc 5987)</span></a> </p>
+<p/>
 <h1 id="rfc.section.6"><a href="#rfc.section.6">6.</a> Acknowledgements</h1>
 <p id="rfc.section.6.p.1">The following people made contributions to this specification: </p>
 <h1 id="rfc.references"><a href="#rfc.references">7.</a> References</h1>
@@ -1272,12 +1246,6 @@
         <b id="draft-ietf-appsawg-uri-get-off-my-lawn-00">[draft-ietf-appsawg-uri-get-off-my-lawn-00]</b>
       </td>
       <td class="top"><a>Nottingham, M.</a>, "<a>Standardising Structure in URIs</a>", I-D draft-ietf-appsawg-uri-get-off-my-lawn-00, September 2013.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="draft-ietf-appsawg-text-markdown-05">[draft-ietf-appsawg-text-markdown-05]</b>
-      </td>
-      <td class="top"><a>Leonard, S.</a>, "<a>The text/markdown Media Type</a>", I-D draft-ietf-appsawg-text-markdown-05, December 2014.</td>
     </tr>
   </tbody>
 </table>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,28 @@
 	  a {
 	  text-decoration: none;
 	  }
+      /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+      a.info {
+          /* This is the key. */
+          position: relative;
+          z-index: 24;
+          text-decoration: none;
+      }
+      a.info:hover {
+          z-index: 25;
+          color: #FFF; background-color: #900;
+      }
+      a.info span { display: none; }
+      a.info:hover span.info {
+          /* The span will display just on :hover state. */
+          display: block;
+          position: absolute;
+          font-size: smaller;
+          top: 2em; left: -5em; width: 15em;
+          padding: 2px; border: 1px solid #333;
+          color: #900; background-color: #EEE;
+          text-align: left;
+      }
 	  a.smpl {
 	  color: black;
 	  }
@@ -397,12 +419,12 @@
 <link href="#rfc.appendix.A.3" rel="Chapter" title="A.3 Why is there no way to indicate ranges for semantic descriptors?"/>
 
 
-  <meta name="generator" content="xml2rfc version 2.4.3 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.4.8 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Amundsen, M., Richardson, L., and M. Foster" />
   <meta name="dct.identifier" content="urn:ietf:id:draft-amundsen-richardson-foster-alps-00.J" />
-  <meta name="dct.issued" scheme="ISO8601" content="2014-8-10" />
+  <meta name="dct.issued" scheme="ISO8601" content="2015-1-19" />
   <meta name="dct.abstract" content="This document describes ALPS, a data format for defining simple descriptions of application-level semantics, similar in complexity to HTML microformats. An ALPS document can be used as a profile to explain the application semantics of a document with an application-agnostic media type (such as HTML, HAL, Collection+JSON, Siren, etc.). This increases the reusability of profile documents across media types.  " />
   <meta name="description" content="This document describes ALPS, a data format for defining simple descriptions of application-level semantics, similar in complexity to HTML microformats. An ALPS document can be used as a profile to explain the application semantics of a document with an application-agnostic media type (such as HTML, HAL, Collection+JSON, Siren, etc.). This increases the reusability of profile documents across media types.  " />
 
@@ -422,7 +444,7 @@
   <td class="right">CA Technologies, Inc.</td>
 </tr>
 <tr>
-  <td class="left">Expires: February 11, 2015</td>
+  <td class="left">Expires: July 23, 2015</td>
   <td class="right">L. Richardson</td>
 </tr>
 <tr>
@@ -439,7 +461,7 @@
 </tr>
 <tr>
   <td class="left"></td>
-  <td class="right">August 10, 2014</td>
+  <td class="right">January 19, 2015</td>
 </tr>
 
     	
@@ -463,11 +485,11 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on February 11, 2015.</p>
+<p>This Internet-Draft will expire on July 23, 2015.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
-<p>Copyright (c) 2014 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>Copyright (c) 2015 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
@@ -750,7 +772,8 @@
 
 <p> </p>
 <h1 id="rfc.section.2.2.2"><a href="#rfc.section.2.2.2">2.2.2.</a> <a href="#prop-doc" id="prop-doc">'doc'</a></h1>
-<p id="rfc.section.2.2.2.p.1">A text field that contains free-form, usually human-readable, text.  The 'doc' element MAY have two properties: <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> and <a href="#prop-format">'format'</a> <cite title="NONE">[prop-format]</cite>.  If the 'href' property appears it SHOULD contain a dereferencable URL that points to human-readable text. If the 'format' property appears it SHOULD contain one of the following values: </p>
+<p id="rfc.section.2.2.2.p.1">A text field that contains free-form, usually human-readable, text.  </p>
+<p id="rfc.section.2.2.2.p.2">The 'doc' element MAY have two properties: <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> and <a href="#prop-format">'format'</a> <cite title="NONE">[prop-format]</cite>.  If the 'href' property appears it SHOULD contain a dereferencable URL that points to human-readable text. If the 'format' property appears it SHOULD contain one of the following values: </p>
 
 <ol>
   <li>"text"</li>
@@ -758,7 +781,9 @@
   <li>"asciidoc"</li>
 </ol>
 
-<p> Any program processing "doc" elements SHOULD honor the "format" directive and parse/render the content appropriately. If the value in the "format" property is not recognized and/or supported, the processing program MUST treat the content as plain text. If no 'format' property is present, the content SHOULD be treated as plain text.  </p>
+<p> </p>
+<p id="rfc.section.2.2.2.p.3">Any program processing "doc" elements SHOULD honor the "format" directive and parse/render the content appropriately. If the value in the "format" property is not recognized and/or supported, the processing program MUST treat the content as plain text. If no 'format' property is present, the content SHOULD be treated as plain text. Support for additional formats, such as <a href="#draft-ietf-appsawg-text-markdown-05">Markdown</a> <cite title="NONE">[draft-ietf-appsawg-text-markdown-05]</cite>, MAY be considered in the future.  </p>
+<p/>
 
 <dl>
   <dt>XML:</dt>
@@ -768,7 +793,7 @@
 </dl>
 
 <p> </p>
-<p id="rfc.section.2.2.2.p.2">A 'doc' element SHOULD appear as a child of <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>. When present, it describes the meaning and use of the related 'descriptor'.  </p>
+<p id="rfc.section.2.2.2.p.5">A 'doc' element SHOULD appear as a child of <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>. When present, it describes the meaning and use of the related 'descriptor'.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -778,7 +803,7 @@
 </dl>
 
 <p> </p>
-<p id="rfc.section.2.2.2.p.3">The 'doc' element MAY appear as a child of <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite>. When present, it describes the purpose of the ALPS document as a whole.  </p>
+<p id="rfc.section.2.2.2.p.6">The 'doc' element MAY appear as a child of <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite>. When present, it describes the purpose of the ALPS document as a whole.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -855,7 +880,8 @@
 <p> </p>
 <p id="rfc.section.2.2.4.p.6">Since the 'ext' element has no specific meaning within this specification, it MUST be ignored by any application that does not understand its meaning.  </p>
 <h1 id="rfc.section.2.2.5"><a href="#rfc.section.2.2.5">2.2.5.</a> <a href="#prop-format" id="prop-format">'format'</a></h1>
-<p id="rfc.section.2.2.5.p.1">Indicates how the text content should be parsed and/or rendered. This version of the spec identifies three possible values for "format": "text", "html", and "asciidoc." Any other values for this attribute are undefined and SHOULD be treated as plain text. If the program does not recognize the value of the "format" property and/or the "format" property is missing, the content SHOULD be treated as plain text.  This property MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> element.  </p>
+<p id="rfc.section.2.2.5.p.1">Indicates how the text content should be parsed and/or rendered. This version of the spec identifies three possible values for "format": "text", "html", and "asciidoc." Any other values for this attribute are undefined and SHOULD be treated as plain text. If the program does not recognize the value of the "format" property and/or the "format" property is missing, the content SHOULD be treated as plain text. Support for additional formats MAY be considered in the future.  </p>
+<p id="rfc.section.2.2.5.p.2">This property MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> element.  </p>
 <h1 id="rfc.section.2.2.6"><a href="#rfc.section.2.2.6">2.2.6.</a> <a href="#prop-href" id="prop-href">'href'</a></h1>
 <p id="rfc.section.2.2.6.p.1">Contains a resolvable URL.  </p>
 <p id="rfc.section.2.2.6.p.2">When it appears as an attribute of <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>, 'href' points to another 'descriptor' either within the existing ALPS document or in another ALPS document.  </p>
@@ -1199,7 +1225,7 @@
 <p> </p>
 <h1 id="rfc.section.5"><a href="#rfc.section.5">5.</a> <a href="#internationalization" id="internationalization">Internationalization Considerations</a></h1>
 <p id="rfc.section.5.p.1">[TK]</p>
-<p/>
+<p><a id="CREF1" class="info">[CREF1]<span class="info">insert text (consider rfc 5987)</span></a> </p>
 <h1 id="rfc.section.6"><a href="#rfc.section.6">6.</a> Acknowledgements</h1>
 <p id="rfc.section.6.p.1">The following people made contributions to this specification: </p>
 <h1 id="rfc.references"><a href="#rfc.references">7.</a> References</h1>
@@ -1246,6 +1272,12 @@
         <b id="draft-ietf-appsawg-uri-get-off-my-lawn-00">[draft-ietf-appsawg-uri-get-off-my-lawn-00]</b>
       </td>
       <td class="top"><a>Nottingham, M.</a>, "<a>Standardising Structure in URIs</a>", I-D draft-ietf-appsawg-uri-get-off-my-lawn-00, September 2013.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="draft-ietf-appsawg-text-markdown-05">[draft-ietf-appsawg-text-markdown-05]</b>
+      </td>
+      <td class="top"><a>Leonard, S.</a>, "<a>The text/markdown Media Type</a>", I-D draft-ietf-appsawg-text-markdown-05, December 2014.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Moved the detail of the "format" property to its section, with an overview in the "doc" section (i.e., swapping them around), adding a "prioritised" list of formats -- including Markdown -- in terms of client support (i.e., plain text must be supported, HTML should be, but AsciiDoc and Markdown are optional).

Corrects original pull request and closes #24