### PR TITLE
Fix xrefs

### DIFF
--- a/draft-00.html
+++ b/draft-00.html
@@ -548,20 +548,20 @@
 <p id="rfc.section.1.p.1">This document describes ALPS, a media type for defining simple descriptions of application-level semantics, similar in complexity to HTML microformats. These descriptions contain both human-readable and machine-readable explanations of the semantics.  An ALPS document can be used as a profile to explain the application semantics of a document with an application-agnostic media type (such as HTML, HAL, Collection+JSON, Siren. etc.).  </p>
 <p id="rfc.section.1.p.2">This document identifies a registry for ALPS documents, (The ALPS Profile Registry or APR). The details of this registry, its goals, and operations are covered in a separate document (TBD).  </p>
 <p id="rfc.section.1.p.3">This document also identifies a process for authoring, publishing, and sharing normative human-readable instructions on applying an ALPS document as a profile to responses of a given media type. For example, a document that describes how to apply the semantics of an ALPS profile to an HTML document.  </p>
-<p id="rfc.section.1.p.4">This document registers two media-type identifiers with the IANA: 'application/alps+xml' ("ALPS+XML") and 'application/alps+json' ("ALPS+JSON").  </p>
+<p id="rfc.section.1.p.4">This document registers two media-type identifiers with the IANA: 'application/alps+xml' ('ALPS+XML') and 'application/alps+json' ('ALPS+JSON').  </p>
 <h1 id="rfc.section.1.1"><a href="#rfc.section.1.1">1.1.</a> Notational Conventions</h1>
 <p id="rfc.section.1.1.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in<a href="#RFC2119">[RFC2119]</a>.  </p>
 <h1 id="rfc.section.1.2"><a href="#rfc.section.1.2">1.2.</a> Motivation</h1>
 <p id="rfc.section.1.2.p.1">When implementing a hypermedia client/server application using a general media type (HTML, Atom, Collection+JSON, etc.), client and server instances need to share an understanding of domain-specific information such as data element names, link relation values, and state transfer parameters. This information is directly related to the application being implemented (e.g. accounting, contact management, etc.) rather than the media type used in the representations.  </p>
 <h1 id="rfc.section.1.2.1"><a href="#rfc.section.1.2.1">1.2.1.</a> Describing Domain-Specific Semantics</h1>
-<p id="rfc.section.1.2.1.p.1">Instead of creating and registering an entirely new media type (i.e. 'application/accounting'), representation authors can create an ALPS document that describes a "profile" of the target domain; one that explains the vital domain-specific semantic descriptors and state transitions. This profile can then be consistently applied to a wide range of media types by server implementors and successfully consumed by client applications. The focus on defining application-level semantics, independent of transfer protocol or media type, makes it possible to serve application-specific representations using an application-agnostic media type.  </p>
+<p id="rfc.section.1.2.1.p.1">Instead of creating and registering an entirely new media type (i.e. 'application/accounting'), representation authors can create an ALPS document that describes a 'profile' of the target domain; one that explains the vital domain-specific semantic descriptors and state transitions. This profile can then be consistently applied to a wide range of media types by server implementors and successfully consumed by client applications. The focus on defining application-level semantics, independent of transfer protocol or media type, makes it possible to serve application-specific representations using an application-agnostic media type.  </p>
 <h1 id="rfc.section.1.2.2"><a href="#rfc.section.1.2.2">1.2.2.</a> ALPS-based Server Implementations</h1>
 <p id="rfc.section.1.2.2.p.1">Server implementors can use ALPS documents as a basis for building domain-specific solutions without having to create their own custom media type or re-invent the vocabulary and transition set for a common domain (e.g.  accounting, microblogging, etc.). Using a preexisting ALPS profile as a guide, servers can map internal data to commonly-understood semantic descriptors and state transitions, increasing the likelihood that existing client applications (those who share the same understanding of the ALPS document) will be able to successfully interact with that server.  </p>
 <h1 id="rfc.section.1.2.3"><a href="#rfc.section.1.2.3">1.2.3.</a> ALPS-based Client Implementations</h1>
-<p id="rfc.section.1.2.3.p.1">Armed with a document's ALPS profile, client applications can associate the ALPS descriptor 'id' and/or 'name' attribute values with the appropriate elements within the document.  Client applications can "code for the profile" and better adjust to detailed changes to the response layout, or even the wholesale replacement of one media type with another.  </p>
+<p id="rfc.section.1.2.3.p.1">Armed with a document's ALPS profile, client applications can associate the ALPS descriptor 'id' and/or 'name' attribute values with the appropriate elements within the document.  Client applications can 'code for the profile' and better adjust to detailed changes to the response layout, or even the wholesale replacement of one media type with another.  </p>
 <h1 id="rfc.section.1.3"><a href="#rfc.section.1.3">1.3.</a> <a href="#example" id="example">A Simple ALPS Example</a></h1>
-<p id="rfc.section.1.3.p.1">Below is an ALPS document that describes elements of a simple request/response interaction in a contact management application. The profile defines a semantic descriptor called "contact", and three subordinate descriptors ("fullName", "email", and "phone").  </p>
-<p id="rfc.section.1.3.p.2">The ALPS document also defines a single, safe state transition, to be represented by a hypermedia control (e.g. HTML.GET form) with the 'id' value of "collection." This hypermedia control has one input value ("nameSearch"). When executed, the response will contain one or more "contact" type items.  </p>
+<p id="rfc.section.1.3.p.1">Below is an ALPS document that describes elements of a simple request/response interaction in a contact management application. The profile defines a semantic descriptor called 'contact', and three subordinate descriptors ('fullName', 'email', and 'phone').  </p>
+<p id="rfc.section.1.3.p.2">The ALPS document also defines a single, safe state transition, to be represented by a hypermedia control (e.g. HTML.GET form) with the 'id' value of 'collection.' This hypermedia control has one input value ('nameSearch'). When executed, the response will contain one or more 'contact' type items.  </p>
 <pre>
  &lt;alps version="1.0"&gt;
   &lt;doc format="text"&gt;A contact list.&lt;/doc&gt;
@@ -588,7 +588,7 @@
 &lt;/alps&gt;
                </pre>
 <p class="figure">ALPS Contact Profile document</p>
-<p id="rfc.section.1.3.p.3">Implementing the ALPS profile above requires implementing the descriptors defined by the ALPS document. In this case, there are two "top level" descriptors: the safe state transition ("collection") and the semantic descriptor "contact". Below is a single HTML document that shows both these elements in a representation.  </p>
+<p id="rfc.section.1.3.p.3">Implementing the ALPS profile above requires implementing the descriptors defined by the ALPS document. In this case, there are two 'top level' descriptors: the safe state transition ('collection') and the semantic descriptor 'contact'. Below is a single HTML document that shows both these elements in a representation.  </p>
 <pre>
 &lt;html&gt;
   &lt;head&gt;
@@ -641,7 +641,7 @@
 &lt;/html&gt;
               </pre>
 <p class="figure">HTML ALPS Contact Representation</p>
-<p id="rfc.section.1.3.p.4">HTML representations implement most ALPS elements using HTML's "class" attribute. The "collection" ID has become the CSS class of an HTML form's submit button.  The "contact" ID has become the CSS class of the TR elements in an HTML table. The subordinate descriptors "fullname","email", and "phone" are rendered as the TD elements of each TR.  </p>
+<p id="rfc.section.1.3.p.4">HTML representations implement most ALPS elements using HTML's 'class' attribute. The 'collection' ID has become the CSS class of an HTML form's submit button.  The 'contact' ID has become the CSS class of the TR elements in an HTML table. The subordinate descriptors 'fullname','email', and 'phone' are rendered as the TD elements of each TR.  </p>
 <p id="rfc.section.1.3.p.5">This HAL document uses the same profile to express the same application-level semantics as the HTML document.  </p>
 <pre>
 &lt;resource href="http://example.org/contacts/"&gt;
@@ -667,7 +667,7 @@
 &lt;/resource&gt;
                     </pre>
 <p class="figure">HAL XML Contacts Representation</p>
-<p id="rfc.section.1.3.p.6">In a HAL representation, all state transitions ("collection" and "item", in this case) are represented as link relations. All data descriptors ("fullName", "email", and "phone") are represented as XML tags named after the descriptors.  </p>
+<p id="rfc.section.1.3.p.6">In a HAL representation, all state transitions ('collection' and 'item', in this case) are represented as link relations. All data descriptors ('fullName', 'email', and 'phone') are represented as XML tags named after the descriptors.  </p>
 <p id="rfc.section.1.3.p.7">This Collection+JSON document uses the ALPS profile to express the same application-level semantics as the HTML and HAL documents.  </p>
 <pre>
 {
@@ -749,18 +749,18 @@
                 
                </pre>
 <p class="figure">Collection+JSON Contacts Representation</p>
-<p id="rfc.section.1.3.p.8">The descriptor "collection" has become the link relation associated with a Collection+JSON query. The descriptors "fullName", "email", and "phone" have become the names of key-value pairs in the items in a Collection+JSON collection.  </p>
+<p id="rfc.section.1.3.p.8">The descriptor 'collection' has become the link relation associated with a Collection+JSON query. The descriptors 'fullName', 'email', and 'phone' have become the names of key-value pairs in the items in a Collection+JSON collection.  </p>
 <h1 id="rfc.section.1.4"><a href="#rfc.section.1.4">1.4.</a> Identifying an ALPS Document</h1>
 <p id="rfc.section.1.4.p.1">An ALPS vocabulary is identified by a unique URL.  This URL SHOULD be assumed to be dereferencable.  All ALPS URLs MUST be unique and all ALPS documents intended for public consumption SHOULD be registered in an ALPS Registry [TK: add text on where/how to find registries -mamund].  </p>
 <p id="rfc.section.1.4.p.2">In order to reduce load on servers responding to ALPS document requests, it is RECOMMENDED that servers use cache control directives that instruct client apps to locally cache the results. Clients making these ALPS document requests SHOULD honor the server's caching directives.  </p>
 <h1 id="rfc.section.2"><a href="#rfc.section.2">2.</a> ALPS Documents</h1>
 <p id="rfc.section.2.p.1">An ALPS document contains a machine-readable collection of identifying strings and their human-readable explanations. An ALPS document can be represented in either XML or JSON format. This section identifies the general elements and properties of an ALPS document, their meaning, and their use, independent of how the document is represented.  <a href="#representations">Section 2.3</a> provides specific details on constructing a valid ALPS document in XML and in JSON format.  </p>
 <h1 id="rfc.section.2.1"><a href="#rfc.section.2.1">2.1.</a> Compliance</h1>
-<p id="rfc.section.2.1.p.1">An implementation is not compliant if it fails to satisfy one or more of the MUST or REQUIRED level requirements. An implementation that satisfies all the MUST or REQUIRED level and all the SHOULD level requirements is said to be "unconditionally compliant"; one that satisfies all the MUST level requirements but not all the SHOULD level requirements is said to be "conditionally compliant." </p>
+<p id="rfc.section.2.1.p.1">An implementation is not compliant if it fails to satisfy one or more of the MUST or REQUIRED level requirements. An implementation that satisfies all the MUST or REQUIRED level and all the SHOULD level requirements is said to be 'unconditionally compliant'; one that satisfies all the MUST level requirements but not all the SHOULD level requirements is said to be 'conditionally compliant.' </p>
 <h1 id="rfc.section.2.2"><a href="#rfc.section.2.2">2.2.</a> ALPS Document Properties</h1>
 <p id="rfc.section.2.2.p.1">The ALPS media type defines a small set of properties. These properties appear in both the XML and JSON formats. Below is a list of the properties that can appear in an ALPS document.  </p>
 <h1 id="rfc.section.2.2.1"><a href="#rfc.section.2.2.1">2.2.1.</a> <a href="#prop-alps" id="prop-alps">'alps'</a></h1>
-<p id="rfc.section.2.2.1.p.1">Indicates the root of the ALPS document. This property is REQUIRED, and it SHOULD have one or more <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite> child properties.  </p>
+<p id="rfc.section.2.2.1.p.1">Indicates the root of the ALPS document. This property is REQUIRED, and it SHOULD have one or more <a href="#prop-descriptor">'descriptor'</a> child properties.  </p>
 <p id="rfc.section.2.2.1.p.2">Examples: </p>
 
 <dl>
@@ -772,7 +772,7 @@
 
 <p> </p>
 <h1 id="rfc.section.2.2.2"><a href="#rfc.section.2.2.2">2.2.2.</a> <a href="#prop-doc" id="prop-doc">'doc'</a></h1>
-<p id="rfc.section.2.2.2.p.1">A text field that contains free-form, usually human-readable, text.  The 'doc' element MAY have two properties: <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> and <a href="#prop-format">'format'</a> <cite title="NONE">[prop-format]</cite>.  If the 'href' property appears it SHOULD contain a dereferencable URL that points to human-readable text. If the 'format' property appears it SHOULD contain one of the following values: "text", "html", "asciidoc", or "markdown".  Any program processing "doc" elements SHOULD honor the "format" directive and parse/render the content appropriately. If the value in the "format" property is not recognized and/or supported, the processing program MUST treat the content as plain text. If no 'format' property is present, the content SHOULD be treated as plain text.  </p>
+<p id="rfc.section.2.2.2.p.1">A text field that contains free-form, usually human-readable, text.  The 'doc' element MAY have two properties: <a href="#prop-href">'href'</a> and <a href="#prop-format">'format'</a>.  If the 'href' property appears it SHOULD contain a dereferencable URL that points to human-readable text. If the 'format' property appears it SHOULD contain one of the following values: 'text', 'html', 'asciidoc', or 'markdown'.  Any program processing 'doc' elements SHOULD honor the 'format' directive and parse/render the content appropriately. If the value in the 'format' property is not recognized and/or supported, the processing program MUST treat the content as plain text. If no 'format' property is present, the content SHOULD be treated as plain text.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -782,7 +782,7 @@
 </dl>
 
 <p> </p>
-<p id="rfc.section.2.2.2.p.2">A 'doc' element SHOULD appear as a child of <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>. When present, it describes the meaning and use of the related 'descriptor'.  </p>
+<p id="rfc.section.2.2.2.p.2">A 'doc' element SHOULD appear as a child of <a href="#prop-descriptor">'descriptor'</a>. When present, it describes the meaning and use of the related 'descriptor'.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -792,7 +792,7 @@
 </dl>
 
 <p> </p>
-<p id="rfc.section.2.2.2.p.3">The 'doc' element MAY appear as a child of <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite>. When present, it describes the purpose of the ALPS document as a whole.  </p>
+<p id="rfc.section.2.2.2.p.3">The 'doc' element MAY appear as a child of <a href="#prop-alps">'alps'</a>. When present, it describes the purpose of the ALPS document as a whole.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -804,14 +804,14 @@
 <p> </p>
 <h1 id="rfc.section.2.2.3"><a href="#rfc.section.2.2.3">2.2.3.</a> <a href="#prop-descriptor" id="prop-descriptor">'descriptor'</a></h1>
 <p id="rfc.section.2.2.3.p.1">A 'descriptor' element defines the semantics of specific data elements or state transitions that MAY exist in an associated representation.  </p>
-<p id="rfc.section.2.2.3.p.2">One or more 'descriptor' elements SHOULD appear as children of <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite>. It may also appear as a child of itself; that is, the 'descriptor' property may be nested.  </p>
-<p id="rfc.section.2.2.3.p.3">The 'descriptor' property SHOULD have either an <a href="#prop-id">'id'</a> <cite title="NONE">[prop-id]</cite> or <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> attribute. It MAY have both. Additionally, the 'descriptor' MAY have any of the following attributes: </p>
+<p id="rfc.section.2.2.3.p.2">One or more 'descriptor' elements SHOULD appear as children of <a href="#prop-alps">'alps'</a>. It may also appear as a child of itself; that is, the 'descriptor' property may be nested.  </p>
+<p id="rfc.section.2.2.3.p.3">The 'descriptor' property SHOULD have either an <a href="#prop-id">'id'</a> or <a href="#prop-href">'href'</a> attribute. It MAY have both. Additionally, the 'descriptor' MAY have any of the following attributes: </p>
 
 <ol>
-  <li><a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> </li>
-  <li><a href="#prop-ext">'ext'</a> <cite title="NONE">[prop-ext]</cite> </li>
-  <li><a href="#prop-name">'name'</a> <cite title="NONE">[prop-name]</cite> </li>
-  <li><a href="#prop-type">'type'</a> <cite title="NONE">[prop-type]</cite> </li>
+  <li><a href="#prop-doc">'doc'</a> </li>
+  <li><a href="#prop-ext">'ext'</a> </li>
+  <li><a href="#prop-name">'name'</a> </li>
+  <li><a href="#prop-type">'type'</a> </li>
 </ol>
 
 <p> </p>
@@ -842,13 +842,13 @@
 <p id="rfc.section.2.2.4.p.2">The 'ext' element has the following properties.  </p>
 
 <ol>
-  <li><a href="#prop-id">id</a> <cite title="NONE">[prop-id]</cite> </li>
-  <li><a href="#prop-href">href</a> <cite title="NONE">[prop-href]</cite> </li>
-  <li><a href="#prop-value">value</a> <cite title="NONE">[prop-value]</cite> </li>
+  <li><a href="#prop-id">'id'</a> </li>
+  <li><a href="#prop-href">'href'</a> </li>
+  <li><a href="#prop-value">'value'</a> </li>
 </ol>
 
 <p> </p>
-<p id="rfc.section.2.2.4.p.3">The <a href="#prop-id">id</a> <cite title="NONE">[prop-id]</cite> property is REQUIRED.  The <a href="#prop-href">href</a> <cite title="NONE">[prop-href]</cite> is RECOMMENDED and it SHOULD point to documentation that explains the use and meaning of this <a href="#prop-ext">ext</a> <cite title="NONE">[prop-ext]</cite> element.  The <a href="#prop-value">value</a> <cite title="NONE">[prop-value]</cite> property is OPTIONAL. The content is undetermined; its meaning and use SHOULD be explained by the document found by de-referencing the <a href="#prop-href">href</a> <cite title="NONE">[prop-href]</cite> property.  </p>
+<p id="rfc.section.2.2.4.p.3">The <a href="#prop-id">'id'</a> property is REQUIRED.  The <a href="#prop-href">'href'</a> is RECOMMENDED and it SHOULD point to documentation that explains the use and meaning of this <a href="#prop-ext">'ext'</a> element.  The <a href="#prop-value">'value'</a> property is OPTIONAL. The content is undetermined; its meaning and use SHOULD be explained by the document found by de-referencing the <a href="#prop-href">'href'</a> property.  </p>
 <p id="rfc.section.2.2.4.p.4">Examples: </p>
 
 <dl>
@@ -862,33 +862,33 @@
 <p id="rfc.section.2.2.4.p.5">The 'ext' element MAY appear as a child of the following elements: </p>
 
 <ol>
-  <li><a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite> </li>
-  <li><a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite> </li>
+  <li><a href="#prop-alps">'alps'</a> </li>
+  <li><a href="#prop-descriptor">'descriptor'</a> </li>
 </ol>
 
 <p> </p>
 <p id="rfc.section.2.2.4.p.6">Since the 'ext' element has no specific meaning within this specification, it MUST be ignored by any application that does not understand its meaning.  </p>
 <h1 id="rfc.section.2.2.5"><a href="#rfc.section.2.2.5">2.2.5.</a> <a href="#prop-format" id="prop-format">'format'</a></h1>
-<p id="rfc.section.2.2.5.p.1">Indicates how the text content should be parsed and/or rendered. This specification identifies a range of possible values for "format": </p>
+<p id="rfc.section.2.2.5.p.1">Indicates how the text content should be parsed and/or rendered. This specification identifies a range of possible values for 'format': </p>
 
 <ul>
-  <li>"text", for plain text, MUST be supported.</li>
-  <li>"html", for HTML, SHOULD be supported.</li>
-  <li>"asciidoc", for AsciiDoc, MAY be supported.</li>
-  <li>"markdown", per <a href="#draft-ietf-appsawg-text-markdown-05">The text/markdown Media Type</a> <cite title="NONE">[draft-ietf-appsawg-text-markdown-05]</cite>, MAY be supported.</li>
+  <li>'text', for plain text, MUST be supported.</li>
+  <li>'html', for HTML, SHOULD be supported.</li>
+  <li>'asciidoc', for AsciiDoc, MAY be supported.</li>
+  <li>'markdown', per <a href="#I-D.ietf-appsawg-text-markdown">The text/markdown Media Type</a> <cite title="NONE">[I-D.ietf-appsawg-text-markdown]</cite>, MAY be supported.</li>
 </ul>
 
-<p> Any other values for this attribute are undefined and SHOULD be treated as plain text. If the program does not recognize the value of the "format" property and/or the "format" property is missing, the content SHOULD be treated as plain text.  </p>
-<p id="rfc.section.2.2.5.p.2">This property MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> element.  </p>
+<p> Any other values for this attribute are undefined and SHOULD be treated as plain text. If the program does not recognize the value of the 'format' property and/or the 'format' property is missing, the content SHOULD be treated as plain text.  </p>
+<p id="rfc.section.2.2.5.p.2">This property MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> element.  </p>
 <h1 id="rfc.section.2.2.6"><a href="#rfc.section.2.2.6">2.2.6.</a> <a href="#prop-href" id="prop-href">'href'</a></h1>
 <p id="rfc.section.2.2.6.p.1">Contains a resolvable URL.  </p>
-<p id="rfc.section.2.2.6.p.2">When it appears as an attribute of a <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>, 'href' points to another 'descriptor' either within the existing ALPS document as a fragment or in another ALPS document as an absolute URL. The URL MUST contain a <a href="#prop-id-frag">fragment</a> <cite title="NONE">[prop-id-frag]</cite> referencing the related 'descriptor'.  </p>
-<p id="rfc.section.2.2.6.p.3">When it appears as an attribute of <a href="#prop-ext">'ext'</a> <cite title="NONE">[prop-ext]</cite>, 'href' points to an external document which provides the defintion of the extension.  </p>
-<p id="rfc.section.2.2.6.p.4">When it appears as an attribute of <a href="#prop-link">'link'</a> <cite title="NONE">[prop-link]</cite>, 'href' points to an external document whose relationship to the current document or 'descriptor' is described by the associated <a href="#prop-rel">'rel'</a> <cite title="NONE">[prop-rel]</cite> property.  </p>
-<p id="rfc.section.2.2.6.p.5">When it appears as an attribute of <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite>, 'href' points to a document that contains human-readable text that describes the associated 'descriptor' or ALPS document.  </p>
+<p id="rfc.section.2.2.6.p.2">When it appears as an attribute of a <a href="#prop-descriptor">'descriptor'</a>, 'href' points to another 'descriptor' either within the existing ALPS document as a fragment or in another ALPS document as an absolute URL. The URL MUST contain a fragment per <a href="#prop-id-frag">Section 2.2.7.2</a> referencing the related 'descriptor'.  </p>
+<p id="rfc.section.2.2.6.p.3">When it appears as an attribute of <a href="#prop-ext">'ext'</a>, 'href' points to an external document which provides the defintion of the extension.  </p>
+<p id="rfc.section.2.2.6.p.4">When it appears as an attribute of <a href="#prop-link">'link'</a>, 'href' points to an external document whose relationship to the current document or 'descriptor' is described by the associated <a href="#prop-rel">'rel'</a> property.  </p>
+<p id="rfc.section.2.2.6.p.5">When it appears as an attribute of <a href="#prop-doc">'doc'</a>, 'href' points to a document that contains human-readable text that describes the associated 'descriptor' or ALPS document.  </p>
 <h1 id="rfc.section.2.2.7"><a href="#rfc.section.2.2.7">2.2.7.</a> <a href="#prop-id" id="prop-id">'id'</a></h1>
-<p id="rfc.section.2.2.7.p.1">A document-wide unique identifier for the related element. This SHOULD appear as an attribute of a <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>.  </p>
-<p id="rfc.section.2.2.7.p.2">The value of this attribute MAY be used as an identifier in the related runtime hypermedia representation. In the example below the ALPS descriptor with an 'id' of "q" is used to identify an HTML input element: </p>
+<p id="rfc.section.2.2.7.p.1">A document-wide unique identifier for the related element. This SHOULD appear as an attribute of a <a href="#prop-descriptor">'descriptor'</a>.  </p>
+<p id="rfc.section.2.2.7.p.2">The value of this attribute MAY be used as an identifier in the related runtime hypermedia representation. In the example below the ALPS descriptor with an 'id' of 'q' is used to identify an HTML input element: </p>
 
 <dl>
   <dt>'id' in ALPS...</dt>
@@ -906,7 +906,7 @@
 <p id="rfc.section.2.2.7.p.3">It should be noted that the exact mapping from ALPS elements (e.g. 'id') to elements within a particular media type (HTML, Collection+JSON, etc.) is covered in separate documents (to be specified).  </p>
 <h1 id="rfc.section.2.2.7.1"><a href="#rfc.section.2.2.7.1">2.2.7.1.</a> <a href="#prop-id-name" id="prop-id-name">ALPS 'id' and 'name' Properties</a></h1>
 <p id="rfc.section.2.2.7.1.p.1">In some cases, media types support non-unique identifiers (e.g. HTML's 'name' property) or will allow the same identifier value for multiple elements in the same representation (e.g. &lt;div id="search" ... /&gt; and &lt;input type="submit" class="search" .../&gt; and &lt;input name="search" ... /&gt;). In those cases, translating that representation into ALPS documents could result in multiple 'id' properties with the same value.  </p>
-<p id="rfc.section.2.2.7.1.p.2">To avoid this, ALPS document designers can add the <a href="#prop-name">name</a> <cite title="NONE">[prop-name]</cite> property to a 'descriptor' to hold the common value ("search") while still using the <a href="#prop-id">id</a> <cite title="NONE">[prop-id]</cite> property to hold a document-wide unique value. For example: </p>
+<p id="rfc.section.2.2.7.1.p.2">To avoid this, ALPS document designers can add the <a href="#prop-name">'name'</a> property to a 'descriptor' to hold the common value ('search') while still using the <a href="#prop-id">'id'</a> property to hold a document-wide unique value. For example: </p>
 <pre>
 &lt;!-- HTML --&gt;
 &lt;div id="search"&gt;
@@ -927,45 +927,45 @@
           </pre>
 <p class="figure">ALPS Description of the same Search Transition</p>
 <h1 id="rfc.section.2.2.7.2"><a href="#rfc.section.2.2.7.2">2.2.7.2.</a> <a href="#prop-id-frag" id="prop-id-frag">Fragment Identifiers and 'id'</a></h1>
-<p id="rfc.section.2.2.7.2.p.1">When applied to an ALPS document, a URI fragment identifier points to the 'descriptor' whose 'id' is the value of the fragment. For example, the fragment identifier "customer" in the URI http://example.com/my-alps-document#customer refers to an ALPS 'descriptor' with 'id' set to "customer".  </p>
+<p id="rfc.section.2.2.7.2.p.1">When applied to an ALPS document, a URI fragment identifier points to the 'descriptor' whose 'id' is the value of the fragment. For example, the fragment identifier 'customer' in the URI http://example.com/my-alps-document#customer refers to an ALPS 'descriptor' with 'id' set to 'customer'.  </p>
 <p id="rfc.section.2.2.7.2.p.2">A relative URL with a fragment identifier within an ALPS document (e.g. href="#customer") refers to a local 'descriptor' within the document containing the reference.  </p>
-<p id="rfc.section.2.2.7.2.p.3">The complete URI to an ALPS 'descriptor' (including the fragment) forms an "abstract semantic type" identifier. This is a resolvable URI (URL) that can be used to indicate the type of a resource; for instance, it can be used as the value of the IANA-registered relation type 'type'.  </p>
+<p id="rfc.section.2.2.7.2.p.3">The complete URI to an ALPS 'descriptor' (including the fragment) forms an 'abstract semantic type' identifier. This is a resolvable URI (URL) that can be used to indicate the type of a resource; for instance, it can be used as the value of the IANA-registered relation type 'type'.  </p>
 <h1 id="rfc.section.2.2.7.3"><a href="#rfc.section.2.2.7.3">2.2.7.3.</a> <a href="#prop-id-rels" id="prop-id-rels">Link Relation Values and 'id' or 'name'</a></h1>
 <p id="rfc.section.2.2.7.3.p.1">Since a state transition 'descriptor' may define a relation type value, it is important to avoid creating conflicts with existing IANA-registered values. If the resulting link relation type is the same as a registered relation type, the descriptor MUST not change the meaning of the IANA relation type.  </p>
 <p id="rfc.section.2.2.7.3.p.2">Further, since the 'id' of a 'descriptor' may define a link relation value per <a href="#prop-descriptor-link-relations">Section 2.2.3.1</a>, if a conflict exists in defining such a descriptor's document-wide unique 'id' with another 'descriptor', the conflicting 'descriptor' MUST define a unique 'id' and MAY specify a 'name' property to resolve the conflict.  </p>
 <p id="rfc.section.2.2.7.3.p.3">If it is unclear whether a registered link relation type in a representation document refers to a relation registered with IANA or a relation registered in an ALPS profile, the semantics of that link are undefined.  </p>
 <h1 id="rfc.section.2.2.8"><a href="#rfc.section.2.2.8">2.2.8.</a> <a href="#prop-link" id="prop-link">'link'</a></h1>
-<p id="rfc.section.2.2.8.p.1">An element that identifies a link between the current ALPS element and some other (possibly external) resource. MAY be a child element of the <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite> and the <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite> elements.  </p>
-<p id="rfc.section.2.2.8.p.2">The 'link' element MUST define the two attributes <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> and <a href="#prop-rel">'rel'</a> <cite title="NONE">[prop-rel]</cite>.  </p>
+<p id="rfc.section.2.2.8.p.1">An element that identifies a link between the current ALPS element and some other (possibly external) resource. MAY be a child element of the <a href="#prop-alps">'alps'</a> and the <a href="#prop-descriptor">'descriptor'</a> elements.  </p>
+<p id="rfc.section.2.2.8.p.2">The 'link' element MUST define the two attributes <a href="#prop-href">'href'</a> and <a href="#prop-rel">'rel'</a>.  </p>
 <h1 id="rfc.section.2.2.9"><a href="#rfc.section.2.2.9">2.2.9.</a> <a href="#prop-name" id="prop-name">'name'</a></h1>
-<p id="rfc.section.2.2.9.p.1">Indicates the name of the <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite> as found in generic representations. It MAY appear as a property of 'descriptor'.  </p>
-<p id="rfc.section.2.2.9.p.2">This is used when the name of the 'descriptor' is used as an <a href="#prop-id">'id'</a> <cite title="NONE">[prop-id]</cite> value elsewhere in the ALPS document. For instance, if a single ALPS document defines a semantic descriptor (data element) called "customer" and a safe descriptor (transition element) also called "customer", they cannot both have 'id="customer"' in the ALPS document. One of them needs to have some other 'id', and to set 'name="customer"'.  </p>
+<p id="rfc.section.2.2.9.p.1">Indicates the name of the <a href="#prop-descriptor">'descriptor'</a> as found in generic representations. It MAY appear as a property of 'descriptor'.  </p>
+<p id="rfc.section.2.2.9.p.2">This is used when the name of the 'descriptor' is used as an <a href="#prop-id">'id'</a> value elsewhere in the ALPS document. For instance, if a single ALPS document defines a semantic descriptor (data element) called 'customer' and a safe descriptor (transition element) also called 'customer', they cannot both have 'id="customer"' in the ALPS document. One of them needs to have some other 'id', and to set 'name="customer"'.  </p>
 <p id="rfc.section.2.2.9.p.3">The use of the 'name' property usually indicates an ambiguity in the application semantics. Thus, it SHOULD only be used when creating an ALPS profile that describes an existing design.  </p>
 <h1 id="rfc.section.2.2.10"><a href="#rfc.section.2.2.10">2.2.10.</a> <a href="#prop-rel" id="prop-rel">'rel'</a></h1>
 <p id="rfc.section.2.2.10.p.1">Contains a <a href="#RFC5988">[RFC5988]</a> approved value: either an extension relation type (a URI) or a registered relation type (a short string).  </p>
-<p id="rfc.section.2.2.10.p.2">Appears as a property of<a href="#prop-link">link</a> <cite title="NONE">[prop-link]</cite>.  </p>
+<p id="rfc.section.2.2.10.p.2">Appears as a property of<a href="#prop-link">'link'</a>.  </p>
 <h1 id="rfc.section.2.2.11"><a href="#rfc.section.2.2.11">2.2.11.</a> <a href="#prop-rt" id="prop-rt">'rt'</a></h1>
-<p id="rfc.section.2.2.11.p.1">Indicates the resource type that will be returned when executing the specified network request. The 'rt' attribute SHOULD appear only on a <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite> with a <a href="#prop-type">'type'</a> <cite title="NONE">[prop-type]</cite> value of 'safe', 'unsafe', or 'idempotent.' </p>
-<p id="rfc.section.2.2.11.p.2">The 'rt' attribute is OPTIONAL and is an opaque string and MAY match the <a href="#prop-id">'id'</a> <cite title="NONE">[prop-id]</cite> of an existing<a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>.  </p>
+<p id="rfc.section.2.2.11.p.1">Indicates the resource type that will be returned when executing the specified network request. The 'rt' attribute SHOULD appear only on a <a href="#prop-descriptor">'descriptor'</a> with a <a href="#prop-type">'type'</a> value of 'safe', 'unsafe', or 'idempotent.' </p>
+<p id="rfc.section.2.2.11.p.2">The 'rt' attribute is OPTIONAL and is an opaque string and MAY match the <a href="#prop-id">'id'</a> of an existing<a href="#prop-descriptor">'descriptor'</a>.  </p>
 <h1 id="rfc.section.2.2.12"><a href="#rfc.section.2.2.12">2.2.12.</a> <a href="#prop-type" id="prop-type">'type'</a></h1>
-<p id="rfc.section.2.2.12.p.1">Indicates the type of hypermedia control to which the element is applied within the resulting representation.  This SHOULD appear for each <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite> element.  The four valid values are: </p>
+<p id="rfc.section.2.2.12.p.1">Indicates the type of hypermedia control to which the element is applied within the resulting representation.  This SHOULD appear for each <a href="#prop-descriptor">'descriptor'</a> element.  The four valid values are: </p>
 
 <dl>
-  <dt>"semantic"</dt>
+  <dt>'semantic'</dt>
   <dd style="margin-left: 8">A state element (e.g. HTML.SPAN, HTML.INPUT, etc.).  </dd>
-  <dt>"safe"</dt>
+  <dt>'safe'</dt>
   <dd style="margin-left: 8">A hypermedia control that triggers a safe, idempotent state transition (e.g. HTTP.GET or HTTP.HEAD).  </dd>
-  <dt>"idempotent"</dt>
+  <dt>'idempotent'</dt>
   <dd style="margin-left: 8">A hypermedia control that triggers an unsafe, idempotent state transition (e.g. HTTP.PUT or HTTP.DELETE).  </dd>
-  <dt>"unsafe"</dt>
+  <dt>'unsafe'</dt>
   <dd style="margin-left: 8">A hypermedia control that triggers an unsafe, non-idempotent state transition (e.g. HTTP.POST).  </dd>
 </dl>
 
 <p> If no 'type' attribute is associated with the element, then 'type="semantic"' is implied.  </p>
 <h1 id="rfc.section.2.2.13"><a href="#rfc.section.2.2.13">2.2.13.</a> <a href="#prop-value" id="prop-value">'value'</a></h1>
-<p id="rfc.section.2.2.13.p.1">Contains a string value. It MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> and the <a href="#prop-ext">'ext'</a> <cite title="NONE">[prop-ext]</cite> elements.  </p>
+<p id="rfc.section.2.2.13.p.1">Contains a string value. It MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> and the <a href="#prop-ext">'ext'</a> elements.  </p>
 <h1 id="rfc.section.2.2.14"><a href="#rfc.section.2.2.14">2.2.14.</a> <a href="#prop-version" id="prop-version">'version'</a></h1>
-<p id="rfc.section.2.2.14.p.1">Indicates the version of the ALPS specification used in the document. This SHOULD appear as a property of the <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite> element.  Currently the only valid value is "1.0". If no value appears, then 'version="1.0"' is implied.  </p>
+<p id="rfc.section.2.2.14.p.1">Indicates the version of the ALPS specification used in the document. This SHOULD appear as a property of the <a href="#prop-alps">'alps'</a> element.  Currently the only valid value is '1.0'. If no value appears, then 'version="1.0"' is implied.  </p>
 <h1 id="rfc.section.2.3"><a href="#rfc.section.2.3">2.3.</a> <a href="#representations" id="representations">ALPS Representations</a></h1>
 <p id="rfc.section.2.3.p.1">An ALPS document may be represented in either XML or JSON format. This section contains notes on how the ALPS elements and attributes appear in each format, along with examples to guide ALPS document authors.  </p>
 <h1 id="rfc.section.2.3.1"><a href="#rfc.section.2.3.1">2.3.1.</a> <a href="#html-representation" id="html-representation">Sample HTML</a></h1>
@@ -990,7 +990,7 @@
 <p class="figure">HTML Sample</p>
 <p id="rfc.section.2.3.1.p.1">Below is a simple HTML document that contains a handful of semantic descriptors and transition instructions.  This document was generated from the XML and JSON ALPS documents that follow. Use this HTML document as a guide when evaluating the XML and JSON examples.  </p>
 <h1 id="rfc.section.2.3.2"><a href="#rfc.section.2.3.2">2.3.2.</a> <a href="#xml-representation" id="xml-representation">XML Representation Example</a></h1>
-<p id="rfc.section.2.3.2.p.1">In the XML version of an ALPS document, the following ALPS properties always appear as XML elements: <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite>, <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite>, <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>, and <a href="#prop-ext">'ext'</a> <cite title="NONE">[prop-ext]</cite>. All other ALPS properties appear as XML attributes.  </p>
+<p id="rfc.section.2.3.2.p.1">In the XML version of an ALPS document, the following ALPS properties always appear as XML elements: <a href="#prop-alps">'alps'</a>, <a href="#prop-doc">'doc'</a>, <a href="#prop-descriptor">'descriptor'</a>, and <a href="#prop-ext">'ext'</a>. All other ALPS properties appear as XML attributes.  </p>
 <h1 id="rfc.section.2.3.2.1"><a href="#rfc.section.2.3.2.1">2.3.2.1.</a> Complete XML Representation</h1>
 <p id="rfc.section.2.3.2.1.p.1">Below is an example of an application/alps+xml representation.  </p>
 <pre>
@@ -1016,7 +1016,7 @@
                           </pre>
 <p class="figure">Complete XML Representation</p>
 <h1 id="rfc.section.2.3.3"><a href="#rfc.section.2.3.3">2.3.3.</a> <a href="#json-representation" id="json-representation">JSON Representation Example</a></h1>
-<p id="rfc.section.2.3.3.p.1">When representing ALPS documents in JSON format, the <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite> and <a href="#prop-ext">'ext'</a> <cite title="NONE">[prop-ext]</cite> properties are always expressed as arrays of anonymous objects - even when there is only one member in the array.  </p>
+<p id="rfc.section.2.3.3.p.1">When representing ALPS documents in JSON format, the <a href="#prop-descriptor">'descriptor'</a> and <a href="#prop-ext">'ext'</a> properties are always expressed as arrays of anonymous objects - even when there is only one member in the array.  </p>
 
 <p>For example:</p>
 <pre>
@@ -1031,7 +1031,7 @@
 ]
               </pre>
 <p class="figure">Arrays in ALPS+JSON</p>
-<p id="rfc.section.2.3.3.p.2">The <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> property is always expressed as a named object.  </p>
+<p id="rfc.section.2.3.3.p.2">The <a href="#prop-doc">'doc'</a> property is always expressed as a named object.  </p>
 <p/>
 
 <p>For example:</p>
@@ -1091,7 +1091,7 @@
 <p/>
 <p id="rfc.section.3.p.3">Not all media types can faithfully represent all ALPS descriptors. For instance, the 'application/json' media type has no standard way of representing hyperlinks. The [details of how to apply ALPS to such a media type will necesarily be incomplete, and it will not be possible to represent some aspects of an ALPS profile in documents in that media type.  </p>
 <h1 id="rfc.section.3.1"><a href="#rfc.section.3.1">3.1.</a> <a href="#linking-to-alps-documents" id="linking-to-alps-documents">Linking to ALPS Documents</a></h1>
-<p id="rfc.section.3.1.p.1">To indicate that an ALPS profile describes the semantics of some representation document, the representation document SHOULD be linked to the ALPS document. The "profile" link relation <a href="#RFC6906">[RFC6906]</a> MUST be used when creating this link.  If the media type of the representation document has no native ability to link to other resources, or no ability to express link relations, the HTTP header 'Link' <a href="#RFC5988">[RFC5988]</a> MAY be used to connect the representation document and the ALPS profile. If the media type of the representation document defines a parameter for linking the document to a profile, that parameter MAY be used to connect the representation document and the ALPS profile.  </p>
+<p id="rfc.section.3.1.p.1">To indicate that an ALPS profile describes the semantics of some representation document, the representation document SHOULD be linked to the ALPS document. The 'profile' link relation <a href="#RFC6906">[RFC6906]</a> MUST be used when creating this link.  If the media type of the representation document has no native ability to link to other resources, or no ability to express link relations, the HTTP header 'Link' <a href="#RFC5988">[RFC5988]</a> MAY be used to connect the representation document and the ALPS profile. If the media type of the representation document defines a parameter for linking the document to a profile, that parameter MAY be used to connect the representation document and the ALPS profile.  </p>
 <p id="rfc.section.3.1.p.2">A single representation document may be described by more than one ALPS profile. If two ALPS profiles give conflicting semantics for the same element, the document linked to earlier in the representation SHOULD take precedence. A profile linked to using the 'Link' header takes precedence over a profile linked to within the representation document itself. A profile linked to using a media type parameter takes precedence over a profile linked to using the 'Link' header and a profile linked to within the representation document itself.  </p>
 <h1 id="rfc.section.4"><a href="#rfc.section.4">4.</a> <a href="#iana-considerations" id="iana-considerations">IANA Considerations</a></h1>
 <p id="rfc.section.4.p.1">This specification establishes two media types: 'application/alps+xml' and 'application/alps+json' </p>
@@ -1260,6 +1260,12 @@
       </td>
       <td class="top"><a>Wilde, E.</a>, "<a href="http://tools.ietf.org/html/rfc6906">The 'profile' Link Relation Type</a>", RFC 6906, March 2013.</td>
     </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC7320">[RFC7320]</b>
+      </td>
+      <td class="top"><a>Nottingham, M.</a>, "<a href="http://tools.ietf.org/html/rfc7320">URI Design and Ownership</a>", BCP 190, RFC 7320, July 2014.</td>
+    </tr>
   </tbody>
 </table>
 <h1 id="rfc.references.2"><a href="#rfc.references.2">7.2.</a> Informative References</h1>
@@ -1267,26 +1273,20 @@
   <tbody>
     <tr>
       <td class="reference">
-        <b id="draft-ietf-appsawg-uri-get-off-my-lawn-00">[draft-ietf-appsawg-uri-get-off-my-lawn-00]</b>
+        <b id="I-D.ietf-appsawg-text-markdown">[I-D.ietf-appsawg-text-markdown]</b>
       </td>
-      <td class="top"><a>Nottingham, M.</a>, "<a>Standardising Structure in URIs</a>", I-D draft-ietf-appsawg-uri-get-off-my-lawn-00, September 2013.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="draft-ietf-appsawg-text-markdown-05">[draft-ietf-appsawg-text-markdown-05]</b>
-      </td>
-      <td class="top"><a>Leonard, S.</a>, "<a>The text/markdown Media Type</a>", I-D draft-ietf-appsawg-text-markdown-05, December 2014.</td>
+      <td class="top"><a>Leonard, S.</a>, "<a href="http://tools.ietf.org/html/draft-ietf-appsawg-text-markdown-05">The text/markdown Media Type</a>", Internet-Draft draft-ietf-appsawg-text-markdown-05, December 2014.</td>
     </tr>
   </tbody>
 </table>
 <h1 id="rfc.appendix.A"><a href="#rfc.appendix.A">Appendix A.</a> Frequently Asked Questions</h1>
 <h1 id="rfc.appendix.A.1"><a href="#rfc.appendix.A.1">A.1.</a> Why are there no URLs in ALPS?</h1>
-<p id="rfc.section.A.1.p.1">ALPS is meant to describe a service in a universal way. The same ALPS description document can be used by many ALPS-compliant servers. Since each service implementation is in charge of their own URL space, ALPS descriptions do not include URLs.  See <a href="#draft-ietf-appsawg-uri-get-off-my-lawn-00">Standardising Structure in URIs</a> <cite title="NONE">[draft-ietf-appsawg-uri-get-off-my-lawn-00]</cite> for more on this principle.  </p>
+<p id="rfc.section.A.1.p.1">ALPS is meant to describe a service in a universal way. The same ALPS description document can be used by many ALPS-compliant servers. Since each service implementation is in charge of their own URL space, ALPS descriptions do not include URLs.  See <a href="#RFC7320">URI Design and Ownership</a> <cite title="NONE">[RFC7320]</cite> for more on this principle.  </p>
 <p id="rfc.section.A.1.p.2">When implementing ALPS-compliant servers, implementors are free to use any URL design they wish.  All that is required is that implementors use the same ALPS profile descriptor 'id' and 'name' properties in the representations. When implementing ALPS-compliant client applications, the URLs will be supplied at runtime by the server represetentations. Client apps only need to recognize the descriptor 'id' and 'name' values from the referenced ALPS profile document.  </p>
 <h1 id="rfc.appendix.A.2"><a href="#rfc.appendix.A.2">A.2.</a> Why is there no workflow component in the ALPS specification?</h1>
-<p id="rfc.section.A.2.p.1">ALPS is not designed to describe workflows or execution paths for a service. Instead, ALPS is designed to describe a shared set of data and actions elements that server MAY implement in order to create a service. Each action descriptor (where the descriptor's type property is set to "safe", "unsafe", or "idemponent") SHOULD describe a state transition that a ALPS-compliant client application can invoke when it is available. Servers are free to implement the transitions they find useful and to arrange them in any order they wish.  ALPS-compliant client applications SHOULD be able to recognize these descriptors when they appear and are free to act upon them directly, render them for humans to invoke, or ignore/hide them completely.  </p>
+<p id="rfc.section.A.2.p.1">ALPS is not designed to describe workflows or execution paths for a service. Instead, ALPS is designed to describe a shared set of data and actions elements that server MAY implement in order to create a service. Each action descriptor (where the descriptor's type property is set to 'safe', 'unsafe', or 'idemponent') SHOULD describe a state transition that a ALPS-compliant client application can invoke when it is available. Servers are free to implement the transitions they find useful and to arrange them in any order they wish.  ALPS-compliant client applications SHOULD be able to recognize these descriptors when they appear and are free to act upon them directly, render them for humans to invoke, or ignore/hide them completely.  </p>
 <h1 id="rfc.appendix.A.3"><a href="#rfc.appendix.A.3">A.3.</a> Why is there no way to indicate ranges for semantic descriptors?</h1>
-<p id="rfc.section.A.3.p.1">For most all service implementations, there are cases where it would be helpful to document a range of possible values for a semantic element. For example, when implementing the descriptor {"id":"size", ...}, one service might want to indicate the list of supported values such as: "small", "meduim", "large", etc. However, another service might have a very different list of possible values such as "standard", "oversized", "undersized", etc. And there may be a service that only supports a single value here and will always supply it ("onesie").  </p>
+<p id="rfc.section.A.3.p.1">For most all service implementations, there are cases where it would be helpful to document a range of possible values for a semantic element. For example, when implementing the descriptor {"id":"size", ...}, one service might want to indicate the list of supported values such as: 'small', 'meduim', 'large', etc. However, another service might have a very different list of possible values such as 'standard', 'oversized', 'undersized', etc. And there may be a service that only supports a single value here and will always supply it ('onesize').  </p>
 <p id="rfc.section.A.3.p.2">Since ALPS is meant to provide a single description that can be used by multiple services, establishing ranges within the ALPS description is considered over-constraining service implementations. Services are free to supply this information within representations at run time. But including them in the global ALPS profile is discouraged.  </p>
 <h1 id="rfc.authors">
   <a href="#rfc.authors">Authors' Addresses</a>

--- a/draft-00.txt
+++ b/draft-00.txt
@@ -94,7 +94,7 @@ Table of Contents
        2.2.6.  'href'  . . . . . . . . . . . . . . . . . . . . . . .  14
        2.2.7.  'id'  . . . . . . . . . . . . . . . . . . . . . . . .  14
        2.2.8.  'link'  . . . . . . . . . . . . . . . . . . . . . . .  16
-       2.2.9.  'name'  . . . . . . . . . . . . . . . . . . . . . . .  17
+       2.2.9.  'name'  . . . . . . . . . . . . . . . . . . . . . . .  16
        2.2.10. 'rel' . . . . . . . . . . . . . . . . . . . . . . . .  17
        2.2.11. 'rt'  . . . . . . . . . . . . . . . . . . . . . . . .  17
        2.2.12. 'type'  . . . . . . . . . . . . . . . . . . . . . . .  17
@@ -103,9 +103,9 @@ Table of Contents
      2.3.  ALPS Representations  . . . . . . . . . . . . . . . . . .  18
        2.3.1.  Sample HTML . . . . . . . . . . . . . . . . . . . . .  18
        2.3.2.  XML Representation Example  . . . . . . . . . . . . .  19
-       2.3.3.  JSON Representation Example . . . . . . . . . . . . .  20
-   3.  Applying ALPS documents to Existing Media Types . . . . . . .  22
-     3.1.  Linking to ALPS Documents . . . . . . . . . . . . . . . .  23
+       2.3.3.  JSON Representation Example . . . . . . . . . . . . .  19
+   3.  Applying ALPS documents to Existing Media Types . . . . . . .  21
+     3.1.  Linking to ALPS Documents . . . . . . . . . . . . . . . .  22
 
 
 
@@ -114,20 +114,20 @@ Amundsen, et al.        Expires September 1, 2015               [Page 2]
 Internet-Draft     Application-Level Profile Semantics     February 2015
 
 
-   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  23
-     4.1.  application/alps+xml  . . . . . . . . . . . . . . . . . .  23
-     4.2.  application/alps+json . . . . . . . . . . . . . . . . . .  25
-   5.  Internationalization Considerations . . . . . . . . . . . . .  26
-   6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  26
-   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  26
-     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  26
-     7.2.  Informative References  . . . . . . . . . . . . . . . . .  26
-   Appendix A.  Frequently Asked Questions . . . . . . . . . . . . .  27
-     A.1.  Why are there no URLs in ALPS?  . . . . . . . . . . . . .  27
+   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  22
+     4.1.  application/alps+xml  . . . . . . . . . . . . . . . . . .  22
+     4.2.  application/alps+json . . . . . . . . . . . . . . . . . .  24
+   5.  Internationalization Considerations . . . . . . . . . . . . .  25
+   6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  25
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  25
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  25
+     7.2.  Informative References  . . . . . . . . . . . . . . . . .  25
+   Appendix A.  Frequently Asked Questions . . . . . . . . . . . . .  26
+     A.1.  Why are there no URLs in ALPS?  . . . . . . . . . . . . .  26
      A.2.  Why is there no workflow component in the ALPS
-           specification?  . . . . . . . . . . . . . . . . . . . . .  27
+           specification?  . . . . . . . . . . . . . . . . . . . . .  26
      A.3.  Why is there no way to indicate ranges for semantic
-           descriptors?  . . . . . . . . . . . . . . . . . . . . . .  27
+           descriptors?  . . . . . . . . . . . . . . . . . . . . . .  26
 
 1.  Introduction
 
@@ -150,8 +150,8 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
    ALPS profile to an HTML document.
 
    This document registers two media-type identifiers with the IANA:
-   'application/alps+xml' ("ALPS+XML") and 'application/alps+json'
-   ("ALPS+JSON").
+   'application/alps+xml' ('ALPS+XML') and 'application/alps+json'
+   ('ALPS+JSON').
 
 1.1.  Notational Conventions
 
@@ -185,7 +185,7 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
    Instead of creating and registering an entirely new media type (i.e.
    'application/accounting'), representation authors can create an ALPS
-   document that describes a "profile" of the target domain; one that
+   document that describes a 'profile' of the target domain; one that
    explains the vital domain-specific semantic descriptors and state
    transitions.  This profile can then be consistently applied to a wide
    range of media types by server implementors and successfully consumed
@@ -211,7 +211,7 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
    Armed with a document's ALPS profile, client applications can
    associate the ALPS descriptor 'id' and/or 'name' attribute values
    with the appropriate elements within the document.  Client
-   applications can "code for the profile" and better adjust to detailed
+   applications can 'code for the profile' and better adjust to detailed
    changes to the response layout, or even the wholesale replacement of
    one media type with another.
 
@@ -230,14 +230,14 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
    Below is an ALPS document that describes elements of a simple
    request/response interaction in a contact management application.
-   The profile defines a semantic descriptor called "contact", and three
-   subordinate descriptors ("fullName", "email", and "phone").
+   The profile defines a semantic descriptor called 'contact', and three
+   subordinate descriptors ('fullName', 'email', and 'phone').
 
    The ALPS document also defines a single, safe state transition, to be
    represented by a hypermedia control (e.g.  HTML.GET form) with the
-   'id' value of "collection."  This hypermedia control has one input
-   value ("nameSearch").  When executed, the response will contain one
-   or more "contact" type items.
+   'id' value of 'collection.'  This hypermedia control has one input
+   value ('nameSearch').  When executed, the response will contain one
+   or more 'contact' type items.
 
     <alps version="1.0">
      <doc format="text">A contact list.</doc>
@@ -267,8 +267,8 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
    Implementing the ALPS profile above requires implementing the
    descriptors defined by the ALPS document.  In this case, there are
-   two "top level" descriptors: the safe state transition ("collection")
-   and the semantic descriptor "contact".  Below is a single HTML
+   two 'top level' descriptors: the safe state transition ('collection')
+   and the semantic descriptor 'contact'.  Below is a single HTML
    document that shows both these elements in a representation.
 
    <html>
@@ -339,10 +339,10 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
 
    HTML representations implement most ALPS elements using HTML's
-   "class" attribute.  The "collection" ID has become the CSS class of
-   an HTML form's submit button.  The "contact" ID has become the CSS
+   'class' attribute.  The 'collection' ID has become the CSS class of
+   an HTML form's submit button.  The 'contact' ID has become the CSS
    class of the TR elements in an HTML table.  The subordinate
-   descriptors "fullname","email", and "phone" are rendered as the TD
+   descriptors 'fullname','email', and 'phone' are rendered as the TD
    elements of each TR.
 
    This HAL document uses the same profile to express the same
@@ -372,9 +372,9 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
                       HAL XML Contacts Representation
 
-   In a HAL representation, all state transitions ("collection" and
-   "item", in this case) are represented as link relations.  All data
-   descriptors ("fullName", "email", and "phone") are represented as XML
+   In a HAL representation, all state transitions ('collection' and
+   'item', in this case) are represented as link relations.  All data
+   descriptors ('fullName', 'email', and 'phone') are represented as XML
    tags named after the descriptors.
 
    This Collection+JSON document uses the ALPS profile to express the
@@ -476,9 +476,9 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
                   Collection+JSON Contacts Representation
 
-   The descriptor "collection" has become the link relation associated
-   with a Collection+JSON query.  The descriptors "fullName", "email",
-   and "phone" have become the names of key-value pairs in the items in
+   The descriptor 'collection' has become the link relation associated
+   with a Collection+JSON query.  The descriptors 'fullName', 'email',
+   and 'phone' have become the names of key-value pairs in the items in
    a Collection+JSON collection.
 
 1.4.  Identifying an ALPS Document
@@ -521,9 +521,9 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
    An implementation is not compliant if it fails to satisfy one or more
    of the MUST or REQUIRED level requirements.  An implementation that
    satisfies all the MUST or REQUIRED level and all the SHOULD level
-   requirements is said to be "unconditionally compliant"; one that
+   requirements is said to be 'unconditionally compliant'; one that
    satisfies all the MUST level requirements but not all the SHOULD
-   level requirements is said to be "conditionally compliant."
+   level requirements is said to be 'conditionally compliant.'
 
 2.2.  ALPS Document Properties
 
@@ -534,8 +534,7 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 2.2.1.  'alps'
 
    Indicates the root of the ALPS document.  This property is REQUIRED,
-   and it SHOULD have one or more 'descriptor' (Section 2.2.3) child
-   properties.
+   and it SHOULD have one or more 'descriptor' child properties.
 
    Examples:
 
@@ -546,14 +545,15 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 2.2.2.  'doc'
 
    A text field that contains free-form, usually human-readable, text.
-   The 'doc' element MAY have two properties: 'href' (Section 2.2.6) and
-   'format' (Section 2.2.5).  If the 'href' property appears it SHOULD
-   contain a dereferencable URL that points to human-readable text.  If
-   the 'format' property appears it SHOULD contain one of the following
-   values: "text", "html", "asciidoc", or "markdown".  Any program
-   processing "doc" elements SHOULD honor the "format" directive and
-   parse/render the content appropriately.  If the value in the "format"
-   property is not recognized and/or supported, the processing program
+   The 'doc' element MAY have two properties: 'href' and 'format'.  If
+   the 'href' property appears it SHOULD contain a dereferencable URL
+   that points to human-readable text.  If the 'format' property appears
+   it SHOULD contain one of the following values: 'text', 'html',
+   'asciidoc', or 'markdown'.  Any program processing 'doc' elements
+   SHOULD honor the 'format' directive and parse/render the content
+   appropriately.  If the value in the 'format' property is not
+   recognized and/or supported, the processing program MUST treat the
+
 
 
 
@@ -562,25 +562,24 @@ Amundsen, et al.        Expires September 1, 2015              [Page 10]
 Internet-Draft     Application-Level Profile Semantics     February 2015
 
 
-   MUST treat the content as plain text.  If no 'format' property is
-   present, the content SHOULD be treated as plain text.
+   content as plain text.  If no 'format' property is present, the
+   content SHOULD be treated as plain text.
 
    XML:  <doc format="html"> <h1>Date of Birth</h1> <p>...</p> </doc>
 
    JSON:  { "doc" : { "format" : "text" : "value" : "Date of Birth ..."
       } }
 
-   A 'doc' element SHOULD appear as a child of 'descriptor'
-   (Section 2.2.3).  When present, it describes the meaning and use of
-   the related 'descriptor'.
+   A 'doc' element SHOULD appear as a child of 'descriptor'.  When
+   present, it describes the meaning and use of the related
+   'descriptor'.
 
    XML:  <descriptor ... > <doc>...</doc> </descriptor>
 
    JSON:  { "descriptor" : { { "doc" : { "value" : "..." } ...  } }
 
-   The 'doc' element MAY appear as a child of 'alps' (Section 2.2.1).
-   When present, it describes the purpose of the ALPS document as a
-   whole.
+   The 'doc' element MAY appear as a child of 'alps'.  When present, it
+   describes the purpose of the ALPS document as a whole.
 
    XML:  <alps> <doc>...</doc> ...  </apls>
 
@@ -592,24 +591,25 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
    elements or state transitions that MAY exist in an associated
    representation.
 
-   One or more 'descriptor' elements SHOULD appear as children of 'alps'
-   (Section 2.2.1).  It may also appear as a child of itself; that is,
-   the 'descriptor' property may be nested.
+   One or more 'descriptor' elements SHOULD appear as children of
+   'alps'.  It may also appear as a child of itself; that is, the
+   'descriptor' property may be nested.
 
-   The 'descriptor' property SHOULD have either an 'id' (Section 2.2.7)
-   or 'href' (Section 2.2.6) attribute.  It MAY have both.
-   Additionally, the 'descriptor' MAY have any of the following
-   attributes:
+   The 'descriptor' property SHOULD have either an 'id' or 'href'
+   attribute.  It MAY have both.  Additionally, the 'descriptor' MAY
+   have any of the following attributes:
 
-   1.  'doc' (Section 2.2.2)
+   1.  'doc'
 
-   2.  'ext' (Section 2.2.4)
+   2.  'ext'
 
-   3.  'name' (Section 2.2.9)
+   3.  'name'
 
-   4.  'type' (Section 2.2.12)
+   4.  'type'
 
-
+   If present, the 'href' property MUST be a dereferenceable URL, that
+   points to another 'descriptor' either within the current ALPS
+   document or in another ALPS document.
 
 
 
@@ -617,10 +617,6 @@ Amundsen, et al.        Expires September 1, 2015              [Page 11]
 
 Internet-Draft     Application-Level Profile Semantics     February 2015
 
-
-   If present, the 'href' property MUST be a dereferenceable URL, that
-   points to another 'descriptor' either within the current ALPS
-   document or in another ALPS document.
 
    If 'descriptor' has an 'href' attribute, then 'descriptor' is
    inheriting all the attributes and sub-properties of the descriptor
@@ -669,6 +665,10 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
 
 
+
+
+
+
 Amundsen, et al.        Expires September 1, 2015              [Page 12]
 
 Internet-Draft     Application-Level Profile Semantics     February 2015
@@ -683,19 +683,17 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
    The 'ext' element has the following properties.
 
-   1.  id (Section 2.2.7)
+   1.  'id'
 
-   2.  href (Section 2.2.6)
+   2.  'href'
 
-   3.  value (Section 2.2.13)
+   3.  'value'
 
-   The id (Section 2.2.7) property is REQUIRED.  The href
-   (Section 2.2.6) is RECOMMENDED and it SHOULD point to documentation
-   that explains the use and meaning of this ext (Section 2.2.4)
-   element.  The value (Section 2.2.13) property is OPTIONAL.  The
-   content is undetermined; its meaning and use SHOULD be explained by
-   the document found by de-referencing the href (Section 2.2.6)
-   property.
+   The 'id' property is REQUIRED.  The 'href' is RECOMMENDED and it
+   SHOULD point to documentation that explains the use and meaning of
+   this 'ext' element.  The 'value' property is OPTIONAL.  The content
+   is undetermined; its meaning and use SHOULD be explained by the
+   document found by de-referencing the 'href' property.
 
    Examples:
 
@@ -707,9 +705,9 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
    The 'ext' element MAY appear as a child of the following elements:
 
-   1.  'alps' (Section 2.2.1)
+   1.  'alps'
 
-   2.  'descriptor' (Section 2.2.3)
+   2.  'descriptor'
 
    Since the 'ext' element has no specific meaning within this
    specification, it MUST be ignored by any application that does not
@@ -719,9 +717,11 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
    Indicates how the text content should be parsed and/or rendered.
    This specification identifies a range of possible values for
-   "format":
+   'format':
 
-   o  "text", for plain text, MUST be supported.
+   o  'text', for plain text, MUST be supported.
+
+   o  'html', for HTML, SHOULD be supported.
 
 
 
@@ -730,53 +730,53 @@ Amundsen, et al.        Expires September 1, 2015              [Page 13]
 Internet-Draft     Application-Level Profile Semantics     February 2015
 
 
-   o  "html", for HTML, SHOULD be supported.
+   o  'asciidoc', for AsciiDoc, MAY be supported.
 
-   o  "asciidoc", for AsciiDoc, MAY be supported.
-
-   o  "markdown", per The text/markdown Media Type
-      [draft-ietf-appsawg-text-markdown-05], MAY be supported.
+   o  'markdown', per The text/markdown Media Type
+      [I-D.ietf-appsawg-text-markdown], MAY be supported.
 
    Any other values for this attribute are undefined and SHOULD be
    treated as plain text.  If the program does not recognize the value
-   of the "format" property and/or the "format" property is missing, the
+   of the 'format' property and/or the 'format' property is missing, the
    content SHOULD be treated as plain text.
 
-   This property MAY appear as an attribute of the 'doc' (Section 2.2.2)
-   element.
+   This property MAY appear as an attribute of the 'doc' element.
 
 2.2.6.  'href'
 
    Contains a resolvable URL.
 
-   When it appears as an attribute of a 'descriptor' (Section 2.2.3),
-   'href' points to another 'descriptor' either within the existing ALPS
-   document as a fragment or in another ALPS document as an absolute
-   URL.  The URL MUST contain a fragment (Section 2.2.7.2) referencing
-   the related 'descriptor'.
+   When it appears as an attribute of a 'descriptor', 'href' points to
+   another 'descriptor' either within the existing ALPS document as a
+   fragment or in another ALPS document as an absolute URL.  The URL
+   MUST contain a fragment per Section 2.2.7.2 referencing the related
+   'descriptor'.
 
-   When it appears as an attribute of 'ext' (Section 2.2.4), 'href'
-   points to an external document which provides the defintion of the
-   extension.
+   When it appears as an attribute of 'ext', 'href' points to an
+   external document which provides the defintion of the extension.
 
-   When it appears as an attribute of 'link' (Section 2.2.8), 'href'
-   points to an external document whose relationship to the current
-   document or 'descriptor' is described by the associated 'rel'
-   (Section 2.2.10) property.
+   When it appears as an attribute of 'link', 'href' points to an
+   external document whose relationship to the current document or
+   'descriptor' is described by the associated 'rel' property.
 
-   When it appears as an attribute of 'doc' (Section 2.2.2), 'href'
-   points to a document that contains human-readable text that describes
-   the associated 'descriptor' or ALPS document.
+   When it appears as an attribute of 'doc', 'href' points to a document
+   that contains human-readable text that describes the associated
+   'descriptor' or ALPS document.
 
 2.2.7.  'id'
 
    A document-wide unique identifier for the related element.  This
-   SHOULD appear as an attribute of a 'descriptor' (Section 2.2.3).
+   SHOULD appear as an attribute of a 'descriptor'.
 
    The value of this attribute MAY be used as an identifier in the
    related runtime hypermedia representation.  In the example below the
-   ALPS descriptor with an 'id' of "q" is used to identify an HTML input
+   ALPS descriptor with an 'id' of 'q' is used to identify an HTML input
    element:
+
+   'id' in ALPS...  <descriptor id="q" type="semantic" />
+
+   ...becomes the 'class' in HTML  <input class="q" type="text" value=""
+      />
 
 
 
@@ -785,11 +785,6 @@ Amundsen, et al.        Expires September 1, 2015              [Page 14]
 
 Internet-Draft     Application-Level Profile Semantics     February 2015
 
-
-   'id' in ALPS...  <descriptor id="q" type="semantic" />
-
-   ...becomes the 'class' in HTML  <input class="q" type="text" value=""
-      />
 
    It should be noted that the exact mapping from ALPS elements (e.g.
    'id') to elements within a particular media type (HTML,
@@ -806,10 +801,9 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
    representation into ALPS documents could result in multiple 'id'
    properties with the same value.
 
-   To avoid this, ALPS document designers can add the name
-   (Section 2.2.9) property to a 'descriptor' to hold the common value
-   ("search") while still using the id (Section 2.2.7) property to hold
-   a document-wide unique value.  For example:
+   To avoid this, ALPS document designers can add the 'name' property to
+   a 'descriptor' to hold the common value ('search') while still using
+   the 'id' property to hold a document-wide unique value.  For example:
 
    <!-- HTML -->
    <div id="search">
@@ -830,7 +824,13 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
               ALPS Description of the same Search Transition
 
+2.2.7.2.  Fragment Identifiers and 'id'
 
+   When applied to an ALPS document, a URI fragment identifier points to
+   the 'descriptor' whose 'id' is the value of the fragment.  For
+   example, the fragment identifier 'customer' in the URI
+   http://example.com/my-alps-document#customer refers to an ALPS
+   'descriptor' with 'id' set to 'customer'.
 
 
 
@@ -842,20 +842,12 @@ Amundsen, et al.        Expires September 1, 2015              [Page 15]
 Internet-Draft     Application-Level Profile Semantics     February 2015
 
 
-2.2.7.2.  Fragment Identifiers and 'id'
-
-   When applied to an ALPS document, a URI fragment identifier points to
-   the 'descriptor' whose 'id' is the value of the fragment.  For
-   example, the fragment identifier "customer" in the URI
-   http://example.com/my-alps-document#customer refers to an ALPS
-   'descriptor' with 'id' set to "customer".
-
    A relative URL with a fragment identifier within an ALPS document
    (e.g. href="#customer") refers to a local 'descriptor' within the
    document containing the reference.
 
    The complete URI to an ALPS 'descriptor' (including the fragment)
-   forms an "abstract semantic type" identifier.  This is a resolvable
+   forms an 'abstract semantic type' identifier.  This is a resolvable
    URI (URL) that can be used to indicate the type of a resource; for
    instance, it can be used as the value of the IANA-registered relation
    type 'type'.
@@ -883,12 +875,20 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
    An element that identifies a link between the current ALPS element
    and some other (possibly external) resource.  MAY be a child element
-   of the 'alps' (Section 2.2.1) and the 'descriptor' (Section 2.2.3)
-   elements.
+   of the 'alps' and the 'descriptor' elements.
 
-   The 'link' element MUST define the two attributes 'href'
-   (Section 2.2.6) and 'rel' (Section 2.2.10).
+   The 'link' element MUST define the two attributes 'href' and 'rel'.
 
+2.2.9.  'name'
+
+   Indicates the name of the 'descriptor' as found in generic
+   representations.  It MAY appear as a property of 'descriptor'.
+
+   This is used when the name of the 'descriptor' is used as an 'id'
+   value elsewhere in the ALPS document.  For instance, if a single ALPS
+   document defines a semantic descriptor (data element) called
+   'customer' and a safe descriptor (transition element) also called
+   'customer', they cannot both have 'id="customer"' in the ALPS
 
 
 
@@ -898,18 +898,7 @@ Amundsen, et al.        Expires September 1, 2015              [Page 16]
 Internet-Draft     Application-Level Profile Semantics     February 2015
 
 
-2.2.9.  'name'
-
-   Indicates the name of the 'descriptor' (Section 2.2.3) as found in
-   generic representations.  It MAY appear as a property of
-   'descriptor'.
-
-   This is used when the name of the 'descriptor' is used as an 'id'
-   (Section 2.2.7) value elsewhere in the ALPS document.  For instance,
-   if a single ALPS document defines a semantic descriptor (data
-   element) called "customer" and a safe descriptor (transition element)
-   also called "customer", they cannot both have 'id="customer"' in the
-   ALPS document.  One of them needs to have some other 'id', and to set
+   document.  One of them needs to have some other 'id', and to set
    'name="customer"'.
 
    The use of the 'name' property usually indicates an ambiguity in the
@@ -921,29 +910,40 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
    Contains a [RFC5988] approved value: either an extension relation
    type (a URI) or a registered relation type (a short string).
 
-   Appears as a property oflink (Section 2.2.8).
+   Appears as a property of'link'.
 
 2.2.11.  'rt'
 
    Indicates the resource type that will be returned when executing the
    specified network request.  The 'rt' attribute SHOULD appear only on
-   a 'descriptor' (Section 2.2.3) with a 'type' (Section 2.2.12) value
-   of 'safe', 'unsafe', or 'idempotent.'
+   a 'descriptor' with a 'type' value of 'safe', 'unsafe', or
+   'idempotent.'
 
    The 'rt' attribute is OPTIONAL and is an opaque string and MAY match
-   the 'id' (Section 2.2.7) of an existing'descriptor' (Section 2.2.3).
+   the 'id' of an existing'descriptor'.
 
 2.2.12.  'type'
 
    Indicates the type of hypermedia control to which the element is
    applied within the resulting representation.  This SHOULD appear for
-   each 'descriptor' (Section 2.2.3) element.  The four valid values
-   are:
+   each 'descriptor' element.  The four valid values are:
 
-   "semantic"  A state element (e.g.  HTML.SPAN, HTML.INPUT, etc.).
+   'semantic'  A state element (e.g.  HTML.SPAN, HTML.INPUT, etc.).
 
-   "safe"  A hypermedia control that triggers a safe, idempotent state
+   'safe'  A hypermedia control that triggers a safe, idempotent state
       transition (e.g.  HTTP.GET or HTTP.HEAD).
+
+   'idempotent'  A hypermedia control that triggers an unsafe,
+      idempotent state transition (e.g.  HTTP.PUT or HTTP.DELETE).
+
+   'unsafe'  A hypermedia control that triggers an unsafe, non-
+      idempotent state transition (e.g.  HTTP.POST).
+
+   If no 'type' attribute is associated with the element, then
+   'type="semantic"' is implied.
+
+
+
 
 
 
@@ -954,26 +954,17 @@ Amundsen, et al.        Expires September 1, 2015              [Page 17]
 Internet-Draft     Application-Level Profile Semantics     February 2015
 
 
-   "idempotent"  A hypermedia control that triggers an unsafe,
-      idempotent state transition (e.g.  HTTP.PUT or HTTP.DELETE).
-
-   "unsafe"  A hypermedia control that triggers an unsafe, non-
-      idempotent state transition (e.g.  HTTP.POST).
-
-   If no 'type' attribute is associated with the element, then
-   'type="semantic"' is implied.
-
 2.2.13.  'value'
 
    Contains a string value.  It MAY appear as an attribute of the 'doc'
-   (Section 2.2.2) and the 'ext' (Section 2.2.4) elements.
+   and the 'ext' elements.
 
 2.2.14.  'version'
 
    Indicates the version of the ALPS specification used in the document.
-   This SHOULD appear as a property of the 'alps' (Section 2.2.1)
-   element.  Currently the only valid value is "1.0".  If no value
-   appears, then 'version="1.0"' is implied.
+   This SHOULD appear as a property of the 'alps' element.  Currently
+   the only valid value is '1.0'.  If no value appears, then
+   'version="1.0"' is implied.
 
 2.3.  ALPS Representations
 
@@ -988,27 +979,6 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
    descriptors and transition instructions.  This document was generated
    from the XML and JSON ALPS documents that follow.  Use this HTML
    document as a guide when evaluating the XML and JSON examples.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Amundsen, et al.        Expires September 1, 2015              [Page 18]
-
-Internet-Draft     Application-Level Profile Semantics     February 2015
-
 
    <!-- sample HTML document -->
    <html>
@@ -1029,42 +999,26 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
                                 HTML Sample
 
+
+
+
+
+
+
+Amundsen, et al.        Expires September 1, 2015              [Page 18]
+
+Internet-Draft     Application-Level Profile Semantics     February 2015
+
+
 2.3.2.  XML Representation Example
 
    In the XML version of an ALPS document, the following ALPS properties
-   always appear as XML elements: 'alps' (Section 2.2.1), 'doc'
-   (Section 2.2.2), 'descriptor' (Section 2.2.3), and 'ext'
-   (Section 2.2.4).  All other ALPS properties appear as XML attributes.
+   always appear as XML elements: 'alps', 'doc', 'descriptor', and
+   'ext'.  All other ALPS properties appear as XML attributes.
 
 2.3.2.1.  Complete XML Representation
 
    Below is an example of an application/alps+xml representation.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Amundsen, et al.        Expires September 1, 2015              [Page 19]
-
-Internet-Draft     Application-Level Profile Semantics     February 2015
-
 
    <?xml version="1.0"?>
    <alps version="1.0">
@@ -1090,10 +1044,27 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
 2.3.3.  JSON Representation Example
 
-   When representing ALPS documents in JSON format, the 'descriptor'
-   (Section 2.2.3) and 'ext' (Section 2.2.4) properties are always
-   expressed as arrays of anonymous objects - even when there is only
-   one member in the array.
+   When representing ALPS documents in JSON format, the 'descriptor' and
+   'ext' properties are always expressed as arrays of anonymous objects
+   - even when there is only one member in the array.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Amundsen, et al.        Expires September 1, 2015              [Page 19]
+
+Internet-Draft     Application-Level Profile Semantics     February 2015
+
 
    For example:
 
@@ -1109,18 +1080,7 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
                             Arrays in ALPS+JSON
 
-   The 'doc' (Section 2.2.2) property is always expressed as a named
-   object.
-
-
-
-
-
-
-Amundsen, et al.        Expires September 1, 2015              [Page 20]
-
-Internet-Draft     Application-Level Profile Semantics     February 2015
-
+   The 'doc' property is always expressed as a named object.
 
    For example:
 
@@ -1157,23 +1117,7 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Amundsen, et al.        Expires September 1, 2015              [Page 21]
+Amundsen, et al.        Expires September 1, 2015              [Page 20]
 
 Internet-Draft     Application-Level Profile Semantics     February 2015
 
@@ -1229,7 +1173,7 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
 
 
-Amundsen, et al.        Expires September 1, 2015              [Page 22]
+Amundsen, et al.        Expires September 1, 2015              [Page 21]
 
 Internet-Draft     Application-Level Profile Semantics     February 2015
 
@@ -1248,7 +1192,7 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
    To indicate that an ALPS profile describes the semantics of some
    representation document, the representation document SHOULD be linked
-   to the ALPS document.  The "profile" link relation [RFC6906] MUST be
+   to the ALPS document.  The 'profile' link relation [RFC6906] MUST be
    used when creating this link.  If the media type of the
    representation document has no native ability to link to other
    resources, or no ability to express link relations, the HTTP header
@@ -1285,7 +1229,7 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
 
 
-Amundsen, et al.        Expires September 1, 2015              [Page 23]
+Amundsen, et al.        Expires September 1, 2015              [Page 22]
 
 Internet-Draft     Application-Level Profile Semantics     February 2015
 
@@ -1341,7 +1285,7 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
 
 
-Amundsen, et al.        Expires September 1, 2015              [Page 24]
+Amundsen, et al.        Expires September 1, 2015              [Page 23]
 
 Internet-Draft     Application-Level Profile Semantics     February 2015
 
@@ -1397,7 +1341,7 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
 
 
 
-Amundsen, et al.        Expires September 1, 2015              [Page 25]
+Amundsen, et al.        Expires September 1, 2015              [Page 24]
 
 Internet-Draft     Application-Level Profile Semantics     February 2015
 
@@ -1440,20 +1384,20 @@ Internet-Draft     Application-Level Profile Semantics     February 2015
    [RFC6906]  Wilde, E., "The 'profile' Link Relation Type", RFC 6906,
               March 2013.
 
+   [RFC7320]  Nottingham, M., "URI Design and Ownership", BCP 190, RFC
+              7320, July 2014.
+
 7.2.  Informative References
 
-   [draft-ietf-appsawg-uri-get-off-my-lawn-00]
-              Nottingham, M., "Standardising Structure in URIs", I-D
-              draft-ietf-appsawg-uri-get-off-my-lawn-00, September 2013.
-
-   [draft-ietf-appsawg-text-markdown-05]
-              Leonard, S., "The text/markdown Media Type", I-D draft-
-              ietf-appsawg-text-markdown-05, December 2014.
+   [I-D.ietf-appsawg-text-markdown]
+              Leonard, S., "The text/markdown Media Type", draft-ietf-
+              appsawg-text-markdown-05 (work in progress), December
+              2014.
 
 
 
 
-Amundsen, et al.        Expires September 1, 2015              [Page 26]
+Amundsen, et al.        Expires September 1, 2015              [Page 25]
 
 Internet-Draft     Application-Level Profile Semantics     February 2015
 
@@ -1465,9 +1409,8 @@ A.1.  Why are there no URLs in ALPS?
    ALPS is meant to describe a service in a universal way.  The same
    ALPS description document can be used by many ALPS-compliant servers.
    Since each service implementation is in charge of their own URL
-   space, ALPS descriptions do not include URLs.  See Standardising
-   Structure in URIs [draft-ietf-appsawg-uri-get-off-my-lawn-00] for
-   more on this principle.
+   space, ALPS descriptions do not include URLs.  See URI Design and
+   Ownership [RFC7320] for more on this principle.
 
    When implementing ALPS-compliant servers, implementors are free to
    use any URL design they wish.  All that is required is that
@@ -1484,7 +1427,7 @@ A.2.  Why is there no workflow component in the ALPS specification?
    service.  Instead, ALPS is designed to describe a shared set of data
    and actions elements that server MAY implement in order to create a
    service.  Each action descriptor (where the descriptor's type
-   property is set to "safe", "unsafe", or "idemponent") SHOULD describe
+   property is set to 'safe', 'unsafe', or 'idemponent') SHOULD describe
    a state transition that a ALPS-compliant client application can
    invoke when it is available.  Servers are free to implement the
    transitions they find useful and to arrange them in any order they
@@ -1499,23 +1442,22 @@ A.3.  Why is there no way to indicate ranges for semantic descriptors?
    be helpful to document a range of possible values for a semantic
    element.  For example, when implementing the descriptor {"id":"size",
    ...}, one service might want to indicate the list of supported values
-   such as: "small", "meduim", "large", etc.  However, another service
+   such as: 'small', 'meduim', 'large', etc.  However, another service
    might have a very different list of possible values such as
-   "standard", "oversized", "undersized", etc.  And there may be a
+   'standard', 'oversized', 'undersized', etc.  And there may be a
    service that only supports a single value here and will always supply
-   it ("onesie").
+   it ('onesize').
+
+   Since ALPS is meant to provide a single description that can be used
+   by multiple services, establishing ranges within the ALPS description
 
 
 
-
-
-Amundsen, et al.        Expires September 1, 2015              [Page 27]
+Amundsen, et al.        Expires September 1, 2015              [Page 26]
 
 Internet-Draft     Application-Level Profile Semantics     February 2015
 
 
-   Since ALPS is meant to provide a single description that can be used
-   by multiple services, establishing ranges within the ALPS description
    is considered over-constraining service implementations.  Services
    are free to supply this information within representations at run
    time.  But including them in the global ALPS profile is discouraged.
@@ -1565,4 +1507,6 @@ Authors' Addresses
 
 
 
-Amundsen, et al.        Expires September 1, 2015              [Page 28]
+
+
+Amundsen, et al.        Expires September 1, 2015              [Page 27]

--- a/draft-00.xml
+++ b/draft-00.xml
@@ -7,6 +7,7 @@
         <!ENTITY rfc4627 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4627.xml">
         <!ENTITY rfc5988 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5988.xml">
         <!ENTITY rfc6906 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6906.xml">
+        <!ENTITY rfc7320 PUBLIC "" "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7320.xml">
         ]>
 <!-- ref commands -->
 <?rfc comments="yes"?>
@@ -465,7 +466,7 @@
           <t>
             Indicates the root of the ALPS document. This
             property is REQUIRED, and it SHOULD have one or more
-            <xref target="prop-descriptor">'descriptor'</xref>
+            <xref target="prop-descriptor" format="title"/>
             child properties.
           </t>
           <t>
@@ -485,9 +486,9 @@
             A text field that contains free-form, usually
             human-readable, text.
             The 'doc' element MAY have two properties:
-            <xref target="prop-href">'href'</xref>
+            <xref target="prop-href" format="title"/>
             and
-            <xref target="prop-format">'format'</xref>.
+            <xref target="prop-format" format="title"/>.
             If the 'href' property appears it SHOULD contain a
             dereferencable URL that points to human-readable text. If
             the 'format' property appears it SHOULD contain one of the
@@ -514,7 +515,7 @@
           </t>
           <t>
             A 'doc' element SHOULD appear as a child of
-            <xref target="prop-descriptor">'descriptor'</xref>. When
+            <xref target="prop-descriptor" format="title"/>. When
             present, it describes the meaning and use of the
             related 'descriptor'.
             <list style="hanging">
@@ -533,7 +534,7 @@
             </list>
           </t>
           <t>
-            The 'doc' element MAY appear as a child of <xref target="prop-alps">'alps'</xref>. When present, it
+            The 'doc' element MAY appear as a child of <xref target="prop-alps" format="title"/>. When present, it
             describes the purpose of the ALPS document as a
             whole.
             <list style="hanging">
@@ -559,30 +560,30 @@
           </t>
           <t>
             One or more 'descriptor' elements
-            SHOULD appear as children of <xref target="prop-alps">'alps'</xref>. It may also appear
+            SHOULD appear as children of <xref target="prop-alps" format="title"/>. It may also appear
             as a child of itself; that is, the 'descriptor'
             property may be nested.
           </t>
           <t>
             The 'descriptor' property SHOULD have either an
-            <xref target="prop-id">'id'</xref>
+            <xref target="prop-id" format="title"/>
             or
-            <xref target="prop-href">'href'</xref>
+            <xref target="prop-href" format="title"/>
             attribute. It MAY
             have both. Additionally, the 'descriptor' MAY have any
             of the following attributes:
             <list style="numbers">
               <t>
-                <xref target="prop-doc">'doc'</xref>
+                <xref target="prop-doc" format="title"/>
               </t>
               <t>
-                <xref target="prop-ext">'ext'</xref>
+                <xref target="prop-ext" format="title"/>
               </t>
               <t>
-                <xref target="prop-name">'name'</xref>
+                <xref target="prop-name" format="title"/>
               </t>
               <t>
-                <xref target="prop-type">'type'</xref>
+                <xref target="prop-type" format="title"/>
               </t>
             </list>
           </t>
@@ -663,33 +664,33 @@
             The 'ext' element has the following properties.
             <list style="numbers">
               <t>
-                <xref target="prop-id">id</xref>
+                <xref target="prop-id" format="title"/>
               </t>
               <t>
-                <xref target="prop-href">href</xref>
+                <xref target="prop-href" format="title"/>
               </t>
               <t>
-                <xref target="prop-value">value</xref>
+                <xref target="prop-value" format="title"/>
               </t>
             </list>
           </t>
           <t>
             The
-            <xref target="prop-id">id</xref>
+            <xref target="prop-id" format="title"/>
             property is REQUIRED.
             The
-            <xref target="prop-href">href</xref>
+            <xref target="prop-href" format="title"/>
             is RECOMMENDED and
             it SHOULD point to documentation that explains the
             use and meaning of this
-            <xref target="prop-ext">ext</xref>
+            <xref target="prop-ext" format="title"/>
             element.
             The
-            <xref target="prop-value">value</xref>
+            <xref target="prop-value" format="title"/>
             property is OPTIONAL. The content is undetermined; its
             meaning and use SHOULD be explained by the document found
             by de-referencing the
-            <xref target="prop-href">href</xref>
+            <xref target="prop-href" format="title"/>
             property.
           </t>
           <t>
@@ -711,10 +712,10 @@
             elements:
             <list style="numbers">
               <t>
-                <xref target="prop-alps">'alps'</xref>
+                <xref target="prop-alps" format="title"/>
               </t>
               <t>
-                <xref target="prop-descriptor">'descriptor'</xref>
+                <xref target="prop-descriptor" format="title"/>
               </t>
             </list>
           </t>
@@ -734,7 +735,7 @@
               <t>"html", for HTML, SHOULD be supported.</t>
               <t>"asciidoc", for AsciiDoc, MAY be supported.</t>
               <t>"markdown", per
-              <xref target="draft-ietf-appsawg-text-markdown-05">The text/markdown Media Type</xref>,
+              <xref target="I-D.ietf-appsawg-text-markdown">The text/markdown Media Type</xref>,
               MAY be supported.</t>
             </list>
             Any other values for this attribute are undefined and SHOULD
@@ -745,7 +746,7 @@
           </t>
           <t>
             This property MAY appear as an attribute of the
-            <xref target="prop-doc">'doc'</xref> element.
+            <xref target="prop-doc" format="title"/> element.
           </t>
         </section>
         <section anchor="prop-href" title="'href'">
@@ -753,29 +754,29 @@
             Contains a resolvable URL.
           </t>
           <t>
-            When it appears as an attribute of a <xref target="prop-descriptor">'descriptor'</xref>, 'href'
+            When it appears as an attribute of a <xref target="prop-descriptor" format="title"/>, 'href'
             points to another 'descriptor' either within the
             existing ALPS document as a fragment or in another ALPS document as an absolute URL. The URL MUST contain
-            a <xref target="prop-id-frag">fragment</xref> referencing the related 'descriptor'.
+            a fragment per <xref target="prop-id-frag"/> referencing the related 'descriptor'.
           </t>
           <t>
-            When it appears as an attribute of <xref target="prop-ext">'ext'</xref>, 'href' points to an
+            When it appears as an attribute of <xref target="prop-ext" format="title"/>, 'href' points to an
             external document which provides the defintion of
             the extension.
           </t>
           <t>
             When it appears as an attribute of
-            <xref target="prop-link">'link'</xref>,
+            <xref target="prop-link" format="title"/>,
             'href' points to an
             external document whose relationship to the current
             document or 'descriptor' is described by
             the associated
-            <xref target="prop-rel">'rel'</xref>
+            <xref target="prop-rel" format="title"/>
             property.
           </t>
           <t>
             When it appears as an attribute of
-            <xref target="prop-doc">'doc'</xref>, 'href' points to a
+            <xref target="prop-doc" format="title"/>, 'href' points to a
             document that contains human-readable text that describes
             the associated 'descriptor' or ALPS document.
           </t>
@@ -784,7 +785,7 @@
           <t>
             A document-wide unique identifier for the related
             element. This SHOULD appear as an attribute of a
-            <xref target="prop-descriptor">'descriptor'</xref>.
+            <xref target="prop-descriptor" format="title"/>.
           </t>
           <t>
             The value of this attribute MAY be used as an identifier
@@ -818,9 +819,9 @@
             </t>
             <t>
               To avoid this, ALPS document designers can add the
-              <xref target="prop-name">name</xref>
+              <xref target="prop-name" format="title"/>
               property to a 'descriptor' to hold the common value ("search") while still using the
-              <xref target="prop-id">id</xref>
+              <xref target="prop-id" format="title"/>
               property to hold a document-wide unique value. For example:
             </t>
             <figure title="HTML Representation of a Search Transition">
@@ -894,22 +895,22 @@
           <t>
             An element that identifies a link between the current ALPS element and some
             other (possibly external) resource. MAY be a child element of the
-            <xref target="prop-alps">'alps'</xref>
+            <xref target="prop-alps" format="title"/>
             and the
-            <xref target="prop-descriptor">'descriptor'</xref>
+            <xref target="prop-descriptor" format="title"/>
             elements.
           </t>
           <t>
             The 'link' element MUST define the two attributes
-            <xref target="prop-href">'href'</xref>
+            <xref target="prop-href" format="title"/>
             and
-            <xref target="prop-rel">'rel'</xref>.
+            <xref target="prop-rel" format="title"/>.
           </t>
         </section>
         <section anchor="prop-name" title="'name'">
           <t>
             Indicates the name of the
-            <xref target="prop-descriptor">'descriptor'</xref>
+            <xref target="prop-descriptor" format="title"/>
             as
             found in generic representations. It MAY appear as a
             property of 'descriptor'.
@@ -917,7 +918,7 @@
           <t>
             This is used when the name of the 'descriptor'
             is used as an
-            <xref target="prop-id">'id'</xref>
+            <xref target="prop-id" format="title"/>
             value elsewhere in the
             ALPS document. For instance, if a single ALPS
             document defines a semantic descriptor (data element) called
@@ -942,7 +943,7 @@
             or a registered relation type (a short string).
           </t>
           <t>
-            Appears as a property of<xref target="prop-link">link</xref>.
+            Appears as a property of<xref target="prop-link" format="title"/>.
           </t>
         </section>
         <section anchor="prop-rt" title="'rt'">
@@ -950,17 +951,17 @@
             Indicates the resource type that will be returned when
             executing the specified network request. The 'rt' attribute
             SHOULD appear only on a
-            <xref target="prop-descriptor">'descriptor'</xref>
+            <xref target="prop-descriptor" format="title"/>
             with a
-            <xref target="prop-type">'type'</xref>
+            <xref target="prop-type" format="title"/>
             value of
             'safe', 'unsafe', or 'idempotent.'
           </t>
           <t>
             The 'rt' attribute is OPTIONAL and is an opaque string and MAY match the
-            <xref target="prop-id">'id'</xref>
+            <xref target="prop-id" format="title"/>
             of an
-            existing<xref target="prop-descriptor">'descriptor'</xref>.
+            existing<xref target="prop-descriptor" format="title"/>.
           </t>
         </section>
         <section anchor="prop-type" title="'type'">
@@ -968,7 +969,7 @@
             Indicates the type of hypermedia control to which
             the element is applied within the resulting representation. 
             This SHOULD appear for each 
-            <xref target="prop-descriptor">'descriptor'</xref> element. 
+            <xref target="prop-descriptor" format="title"/> element. 
             The four valid values are:
 
             <list style="hanging">
@@ -1000,9 +1001,9 @@
           <t>
             Contains a string value. It MAY appear as an attribute
             of the
-            <xref target="prop-doc">'doc'</xref>
+            <xref target="prop-doc" format="title"/>
             and the
-            <xref target="prop-ext">'ext'</xref>
+            <xref target="prop-ext" format="title"/>
             elements.
           </t>
         </section>
@@ -1011,7 +1012,7 @@
             Indicates the version of the ALPS specification used
             in the document. This SHOULD appear as a property of
             the
-            <xref target="prop-alps">'alps'</xref>
+            <xref target="prop-alps" format="title"/>
             element.
             Currently
             the only valid value is "1.0". If no value appears,
@@ -1059,9 +1060,9 @@
         <section anchor="xml-representation" title="XML Representation Example">
           <t>
             In the XML version of an ALPS document, the following
-            ALPS properties always appear as XML elements: <xref target="prop-alps">'alps'</xref>, <xref
-                  target="prop-doc">'doc'</xref>, <xref target="prop-descriptor">'descriptor'</xref>, and <xref
-                  target="prop-ext">'ext'</xref>. All other ALPS
+            ALPS properties always appear as XML elements: <xref target="prop-alps" format="title"/>, <xref
+                  target="prop-doc" format="title"/>, <xref target="prop-descriptor" format="title"/>, and <xref
+                  target="prop-ext" format="title"/>. All other ALPS
             properties appear as XML attributes.
           </t>
           <section title="Complete XML Representation">
@@ -1098,9 +1099,9 @@
           <t>
             When representing ALPS documents in JSON format,
             the
-            <xref target="prop-descriptor">'descriptor'</xref>
+            <xref target="prop-descriptor" format="title"/>
             and
-            <xref target="prop-ext">'ext'</xref>
+            <xref target="prop-ext" format="title"/>
             properties are
             always expressed as arrays of anonymous objects - even
             when there is only one member in the array.
@@ -1122,7 +1123,7 @@
           </t>
           <t>
             The
-            <xref target="prop-doc">'doc'</xref>
+            <xref target="prop-doc" format="title"/>
             property is always expressed as a named object.
           </t>
           <t>
@@ -1499,28 +1500,10 @@
       &rfc4627;
       &rfc5988;
       &rfc6906;
+      &rfc7320;
     </references>
     <references title="Informative References">
-      <reference anchor="draft-ietf-appsawg-uri-get-off-my-lawn-00">
-        <front>
-          <title>Standardising Structure in URIs</title>
-          <author initials="M." surname="Nottingham" fullname="Mark Nottingham Postel">
-          </author>
-          <date month="September" year="2013"/>
-        </front>
-        <seriesInfo name="I-D" value="draft-ietf-appsawg-uri-get-off-my-lawn-00"/>
-        <format type="HTML" target="http://tools.ietf.org/html/draft-ietf-appsawg-uri-get-off-my-lawn-00"/>
-      </reference>
-      <reference anchor="draft-ietf-appsawg-text-markdown-05">
-        <front>
-          <title>The text/markdown Media Type</title>
-          <author initials="S." surname="Leonard" fullname="Sean Leonard">
-          </author>
-          <date month="December" year="2014"/>
-        </front>
-        <seriesInfo name="I-D" value="draft-ietf-appsawg-text-markdown-05"/>
-        <format type="HTML" target="http://tools.ietf.org/html/draft-ietf-appsawg-text-markdown-05"/>
-      </reference>
+      <?rfc include="reference.I-D.ietf-appsawg-text-markdown.xml"?>
     </references>
     <section title="Frequently Asked Questions">
       <section title="Why are there no URLs in ALPS?">
@@ -1529,7 +1512,7 @@
           can be used by many ALPS-compliant servers. Since each service implementation is in charge
           of their own URL space, ALPS descriptions do not include URLs.
           See
-          <xref target="draft-ietf-appsawg-uri-get-off-my-lawn-00">Standardising Structure in URIs</xref>
+          <xref target="RFC7320">URI Design and Ownership</xref>
           for more on this principle.
         </t>
         <t>

--- a/draft-00.xml
+++ b/draft-00.xml
@@ -95,8 +95,8 @@
       </t>
       <t>
         This document registers two media-type identifiers with
-        the IANA: 'application/alps+xml' ("ALPS+XML") and
-        'application/alps+json' ("ALPS+JSON").
+        the IANA: 'application/alps+xml' ('ALPS+XML') and
+        'application/alps+json' ('ALPS+JSON').
       </t>
       <section title="Notational Conventions">
         <t>
@@ -125,7 +125,7 @@
             entirely new media type
             (i.e. 'application/accounting'),
             representation authors can create an ALPS
-            document that describes a "profile" of the
+            document that describes a 'profile' of the
             target domain; one that explains the vital
             domain-specific semantic descriptors and state
             transitions. This profile can then be
@@ -163,7 +163,7 @@
             applications can associate the ALPS descriptor 'id' and/or
             'name' attribute values with the appropriate
             elements within the document.
-            Client applications can "code for the profile"
+            Client applications can 'code for the profile'
             and better adjust to detailed changes to the
             response layout, or even the wholesale
             replacement of one media type with another.
@@ -175,18 +175,18 @@
           Below is an ALPS document that describes elements
           of a simple request/response interaction in a
           contact management application. The profile
-          defines a semantic descriptor called "contact",
-          and three subordinate descriptors ("fullName",
-          "email", and "phone").
+          defines a semantic descriptor called 'contact',
+          and three subordinate descriptors ('fullName',
+          'email', and 'phone').
         </t>
         <t>
           The ALPS document also defines a single, safe
           state transition, to be represented by a
           hypermedia control (e.g. HTML.GET form) with the
-          'id' value of "collection." This hypermedia
-          control has one input value ("nameSearch"). When
+          'id' value of 'collection.' This hypermedia
+          control has one input value ('nameSearch'). When
           executed, the response will contain one or more
-          "contact" type items.
+          'contact' type items.
         </t>
         <figure title="ALPS Contact Profile document">
           <artwork><![CDATA[
@@ -218,9 +218,9 @@
         <t>
           Implementing the ALPS profile above requires implementing
           the descriptors defined by the ALPS document. In this case,
-          there are two "top level" descriptors: the safe state
-          transition ("collection") and the semantic descriptor
-          "contact". Below is a single HTML document that shows both
+          there are two 'top level' descriptors: the safe state
+          transition ('collection') and the semantic descriptor
+          'contact'. Below is a single HTML document that shows both
           these elements in a representation.
         </t>
         <figure title="HTML ALPS Contact Representation">
@@ -278,11 +278,11 @@
         </figure>
         <t>
           HTML representations implement most ALPS elements using
-          HTML's "class" attribute. The "collection" ID has become the
+          HTML's 'class' attribute. The 'collection' ID has become the
           CSS class of an HTML form's submit button.
-          The "contact" ID has become the CSS class of the TR elements in an 
-          HTML table. The subordinate descriptors "fullname","email", and 
-          "phone" are rendered as the TD elements of each TR.
+          The 'contact' ID has become the CSS class of the TR elements in an 
+          HTML table. The subordinate descriptors 'fullname','email', and 
+          'phone' are rendered as the TD elements of each TR.
         </t>
         <t>This HAL document uses the same profile to express the same
           application-level semantics as the HTML document.
@@ -313,9 +313,9 @@
                     ]]></artwork>
         </figure>
         <t>In a HAL representation, all state transitions
-          ("collection" and "item", in this case) are represented as
-          link relations. All data descriptors ("fullName", "email",
-          and "phone") are represented as XML tags named after the
+          ('collection' and 'item', in this case) are represented as
+          link relations. All data descriptors ('fullName', 'email',
+          and 'phone') are represented as XML tags named after the
           descriptors.
         </t>
         <t>This Collection+JSON document uses the ALPS profile to
@@ -403,9 +403,9 @@
                 
                ]]></artwork>
         </figure>
-        <t>The descriptor "collection" has become the link
+        <t>The descriptor 'collection' has become the link
           relation associated with a Collection+JSON query. The
-          descriptors "fullName", "email", and "phone" have become
+          descriptors 'fullName', 'email', and 'phone' have become
           the names of key-value pairs in the items in a
           Collection+JSON collection.
         </t>
@@ -449,10 +449,10 @@
           satisfy one or more of the MUST or REQUIRED level
           requirements. An implementation that satisfies all
           the MUST or REQUIRED level and all the SHOULD level
-          requirements is said to be "unconditionally
-          compliant"; one that satisfies all the MUST level
+          requirements is said to be 'unconditionally
+          compliant'; one that satisfies all the MUST level
           requirements but not all the SHOULD level requirements
-          is said to be "conditionally compliant."
+          is said to be 'conditionally compliant.'
         </t>
       </section>
       <section title="ALPS Document Properties">
@@ -492,10 +492,10 @@
             If the 'href' property appears it SHOULD contain a
             dereferencable URL that points to human-readable text. If
             the 'format' property appears it SHOULD contain one of the
-            following values: "text", "html", "asciidoc", or "markdown".
-            Any program processing "doc" elements SHOULD honor the
-            "format" directive and parse/render the content
-            appropriately. If the value in the "format" property is not
+            following values: 'text', 'html', 'asciidoc', or 'markdown'.
+            Any program processing 'doc' elements SHOULD honor the
+            'format' directive and parse/render the content
+            appropriately. If the value in the 'format' property is not
             recognized and/or supported, the processing program MUST
             treat the content as plain text. If no 'format' property is
             present, the content SHOULD be treated as plain text.
@@ -729,18 +729,18 @@
           <t>
             Indicates how the text content should be parsed and/or
             rendered. This specification identifies a range of possible
-            values for "format":
+            values for 'format':
             <list style="symbols">
-              <t>"text", for plain text, MUST be supported.</t>
-              <t>"html", for HTML, SHOULD be supported.</t>
-              <t>"asciidoc", for AsciiDoc, MAY be supported.</t>
-              <t>"markdown", per
+              <t>'text', for plain text, MUST be supported.</t>
+              <t>'html', for HTML, SHOULD be supported.</t>
+              <t>'asciidoc', for AsciiDoc, MAY be supported.</t>
+              <t>'markdown', per
               <xref target="I-D.ietf-appsawg-text-markdown">The text/markdown Media Type</xref>,
               MAY be supported.</t>
             </list>
             Any other values for this attribute are undefined and SHOULD
             be treated as plain text. If the program does not recognize
-            the value of the "format" property and/or the "format"
+            the value of the 'format' property and/or the 'format'
             property is missing, the content SHOULD be treated as plain
             text.
           </t>
@@ -790,7 +790,7 @@
           <t>
             The value of this attribute MAY be used as an identifier
             in the related runtime hypermedia representation. In the
-            example below the ALPS descriptor with an 'id' of "q" is
+            example below the ALPS descriptor with an 'id' of 'q' is
             used to identify an HTML input element:
             <list style="hanging">
               <t hangText="'id' in ALPS..."><![CDATA[
@@ -820,7 +820,7 @@
             <t>
               To avoid this, ALPS document designers can add the
               <xref target="prop-name" format="title"/>
-              property to a 'descriptor' to hold the common value ("search") while still using the
+              property to a 'descriptor' to hold the common value ('search') while still using the
               <xref target="prop-id" format="title"/>
               property to hold a document-wide unique value. For example:
             </t>
@@ -851,9 +851,9 @@
               When applied to an ALPS document, a URI fragment
               identifier points to the 'descriptor' whose
               'id' is the value of the fragment. For example, the fragment
-              identifier "customer" in the URI
+              identifier 'customer' in the URI
               http://example.com/my-alps-document#customer refers to an ALPS
-              'descriptor' with 'id' set to "customer".
+              'descriptor' with 'id' set to 'customer'.
             </t>
             <t>
               A relative URL with a fragment identifier within an ALPS document
@@ -862,7 +862,7 @@
             </t>
             <t>
               The complete URI to an ALPS 'descriptor' (including the
-              fragment) forms an "abstract semantic type"
+              fragment) forms an 'abstract semantic type'
               identifier. This is a resolvable URI (URL) that can
               be used to indicate the type of a resource; for
               instance, it can be used as the value of the
@@ -922,8 +922,8 @@
             value elsewhere in the
             ALPS document. For instance, if a single ALPS
             document defines a semantic descriptor (data element) called
-            "customer" and a safe descriptor (transition element) also called
-            "customer", they cannot both have 'id="customer"' in
+            'customer' and a safe descriptor (transition element) also called
+            'customer', they cannot both have 'id="customer"' in
             the ALPS document. One of them needs to have some
             other 'id', and to set 'name="customer"'.
           </t>
@@ -973,21 +973,21 @@
             The four valid values are:
 
             <list style="hanging">
-              <t hangText="&quot;semantic&quot;">
+              <t hangText="'semantic'">
                 A state element (e.g. HTML.SPAN, HTML.INPUT,
                 etc.).
               </t>
-              <t hangText="&quot;safe&quot;">
+              <t hangText="'safe'">
                 A hypermedia control that triggers a safe,
                 idempotent state transition (e.g. HTTP.GET or
                 HTTP.HEAD).
               </t>
-              <t hangText="&quot;idempotent&quot;">
+              <t hangText="'idempotent'">
                 A hypermedia control that triggers an unsafe,
                 idempotent state transition (e.g. HTTP.PUT or
                 HTTP.DELETE).
               </t>
-              <t hangText="&quot;unsafe&quot;">
+              <t hangText="'unsafe'">
                 A hypermedia control that triggers an unsafe,
                 non-idempotent state transition (e.g. HTTP.POST).
               </t>
@@ -1015,7 +1015,7 @@
             <xref target="prop-alps" format="title"/>
             element.
             Currently
-            the only valid value is "1.0". If no value appears,
+            the only valid value is '1.0'. If no value appears,
             then 'version="1.0"' is implied.
           </t>
         </section>
@@ -1268,7 +1268,7 @@
         <t>
           To indicate that an ALPS profile describes the semantics of
           some representation document, the representation document
-          SHOULD be linked to the ALPS document. The "profile"
+          SHOULD be linked to the ALPS document. The 'profile'
           link relation <xref target="RFC6906" /> MUST be used when creating this link.
           If the media type of the representation
           document has no native ability to link to other resources,
@@ -1528,7 +1528,7 @@
           ALPS is not designed to describe workflows or execution paths for a service. Instead, ALPS
           is designed to describe a shared set of data and actions elements that server MAY implement
           in order to create a service. Each action descriptor (where the descriptor's type property is set to
-          "safe", "unsafe", or "idemponent") SHOULD describe a state transition that a
+          'safe', 'unsafe', or 'idemponent') SHOULD describe a state transition that a
           ALPS-compliant client application can invoke when it is available. Servers are free to
           implement the transitions they find useful and to arrange them in any order they wish.
           ALPS-compliant client applications SHOULD be able to recognize these descriptors when they appear
@@ -1541,9 +1541,9 @@
           For most all service implementations, there are cases where it would be helpful to document
           a range of possible values for a semantic element. For example, when implementing the descriptor
           {"id":"size", ...}, one service might want to indicate the list of supported values such as:
-          "small", "meduim", "large", etc. However, another service might have a very different list of
-          possible values such as "standard", "oversized", "undersized", etc. And there may be a service
-          that only supports a single value here and will always supply it ("onesie").
+          'small', 'meduim', 'large', etc. However, another service might have a very different list of
+          possible values such as 'standard', 'oversized', 'undersized', etc. And there may be a service
+          that only supports a single value here and will always supply it ('onesize').
         </t>
         <t>
           Since ALPS is meant to provide a single description that can be used by multiple services,

--- a/index.html
+++ b/index.html
@@ -548,20 +548,20 @@
 <p id="rfc.section.1.p.1">This document describes ALPS, a media type for defining simple descriptions of application-level semantics, similar in complexity to HTML microformats. These descriptions contain both human-readable and machine-readable explanations of the semantics.  An ALPS document can be used as a profile to explain the application semantics of a document with an application-agnostic media type (such as HTML, HAL, Collection+JSON, Siren. etc.).  </p>
 <p id="rfc.section.1.p.2">This document identifies a registry for ALPS documents, (The ALPS Profile Registry or APR). The details of this registry, its goals, and operations are covered in a separate document (TBD).  </p>
 <p id="rfc.section.1.p.3">This document also identifies a process for authoring, publishing, and sharing normative human-readable instructions on applying an ALPS document as a profile to responses of a given media type. For example, a document that describes how to apply the semantics of an ALPS profile to an HTML document.  </p>
-<p id="rfc.section.1.p.4">This document registers two media-type identifiers with the IANA: 'application/alps+xml' ("ALPS+XML") and 'application/alps+json' ("ALPS+JSON").  </p>
+<p id="rfc.section.1.p.4">This document registers two media-type identifiers with the IANA: 'application/alps+xml' ('ALPS+XML') and 'application/alps+json' ('ALPS+JSON').  </p>
 <h1 id="rfc.section.1.1"><a href="#rfc.section.1.1">1.1.</a> Notational Conventions</h1>
 <p id="rfc.section.1.1.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in<a href="#RFC2119">[RFC2119]</a>.  </p>
 <h1 id="rfc.section.1.2"><a href="#rfc.section.1.2">1.2.</a> Motivation</h1>
 <p id="rfc.section.1.2.p.1">When implementing a hypermedia client/server application using a general media type (HTML, Atom, Collection+JSON, etc.), client and server instances need to share an understanding of domain-specific information such as data element names, link relation values, and state transfer parameters. This information is directly related to the application being implemented (e.g. accounting, contact management, etc.) rather than the media type used in the representations.  </p>
 <h1 id="rfc.section.1.2.1"><a href="#rfc.section.1.2.1">1.2.1.</a> Describing Domain-Specific Semantics</h1>
-<p id="rfc.section.1.2.1.p.1">Instead of creating and registering an entirely new media type (i.e. 'application/accounting'), representation authors can create an ALPS document that describes a "profile" of the target domain; one that explains the vital domain-specific semantic descriptors and state transitions. This profile can then be consistently applied to a wide range of media types by server implementors and successfully consumed by client applications. The focus on defining application-level semantics, independent of transfer protocol or media type, makes it possible to serve application-specific representations using an application-agnostic media type.  </p>
+<p id="rfc.section.1.2.1.p.1">Instead of creating and registering an entirely new media type (i.e. 'application/accounting'), representation authors can create an ALPS document that describes a 'profile' of the target domain; one that explains the vital domain-specific semantic descriptors and state transitions. This profile can then be consistently applied to a wide range of media types by server implementors and successfully consumed by client applications. The focus on defining application-level semantics, independent of transfer protocol or media type, makes it possible to serve application-specific representations using an application-agnostic media type.  </p>
 <h1 id="rfc.section.1.2.2"><a href="#rfc.section.1.2.2">1.2.2.</a> ALPS-based Server Implementations</h1>
 <p id="rfc.section.1.2.2.p.1">Server implementors can use ALPS documents as a basis for building domain-specific solutions without having to create their own custom media type or re-invent the vocabulary and transition set for a common domain (e.g.  accounting, microblogging, etc.). Using a preexisting ALPS profile as a guide, servers can map internal data to commonly-understood semantic descriptors and state transitions, increasing the likelihood that existing client applications (those who share the same understanding of the ALPS document) will be able to successfully interact with that server.  </p>
 <h1 id="rfc.section.1.2.3"><a href="#rfc.section.1.2.3">1.2.3.</a> ALPS-based Client Implementations</h1>
-<p id="rfc.section.1.2.3.p.1">Armed with a document's ALPS profile, client applications can associate the ALPS descriptor 'id' and/or 'name' attribute values with the appropriate elements within the document.  Client applications can "code for the profile" and better adjust to detailed changes to the response layout, or even the wholesale replacement of one media type with another.  </p>
+<p id="rfc.section.1.2.3.p.1">Armed with a document's ALPS profile, client applications can associate the ALPS descriptor 'id' and/or 'name' attribute values with the appropriate elements within the document.  Client applications can 'code for the profile' and better adjust to detailed changes to the response layout, or even the wholesale replacement of one media type with another.  </p>
 <h1 id="rfc.section.1.3"><a href="#rfc.section.1.3">1.3.</a> <a href="#example" id="example">A Simple ALPS Example</a></h1>
-<p id="rfc.section.1.3.p.1">Below is an ALPS document that describes elements of a simple request/response interaction in a contact management application. The profile defines a semantic descriptor called "contact", and three subordinate descriptors ("fullName", "email", and "phone").  </p>
-<p id="rfc.section.1.3.p.2">The ALPS document also defines a single, safe state transition, to be represented by a hypermedia control (e.g. HTML.GET form) with the 'id' value of "collection." This hypermedia control has one input value ("nameSearch"). When executed, the response will contain one or more "contact" type items.  </p>
+<p id="rfc.section.1.3.p.1">Below is an ALPS document that describes elements of a simple request/response interaction in a contact management application. The profile defines a semantic descriptor called 'contact', and three subordinate descriptors ('fullName', 'email', and 'phone').  </p>
+<p id="rfc.section.1.3.p.2">The ALPS document also defines a single, safe state transition, to be represented by a hypermedia control (e.g. HTML.GET form) with the 'id' value of 'collection.' This hypermedia control has one input value ('nameSearch'). When executed, the response will contain one or more 'contact' type items.  </p>
 <pre>
  &lt;alps version="1.0"&gt;
   &lt;doc format="text"&gt;A contact list.&lt;/doc&gt;
@@ -588,7 +588,7 @@
 &lt;/alps&gt;
                </pre>
 <p class="figure">ALPS Contact Profile document</p>
-<p id="rfc.section.1.3.p.3">Implementing the ALPS profile above requires implementing the descriptors defined by the ALPS document. In this case, there are two "top level" descriptors: the safe state transition ("collection") and the semantic descriptor "contact". Below is a single HTML document that shows both these elements in a representation.  </p>
+<p id="rfc.section.1.3.p.3">Implementing the ALPS profile above requires implementing the descriptors defined by the ALPS document. In this case, there are two 'top level' descriptors: the safe state transition ('collection') and the semantic descriptor 'contact'. Below is a single HTML document that shows both these elements in a representation.  </p>
 <pre>
 &lt;html&gt;
   &lt;head&gt;
@@ -641,7 +641,7 @@
 &lt;/html&gt;
               </pre>
 <p class="figure">HTML ALPS Contact Representation</p>
-<p id="rfc.section.1.3.p.4">HTML representations implement most ALPS elements using HTML's "class" attribute. The "collection" ID has become the CSS class of an HTML form's submit button.  The "contact" ID has become the CSS class of the TR elements in an HTML table. The subordinate descriptors "fullname","email", and "phone" are rendered as the TD elements of each TR.  </p>
+<p id="rfc.section.1.3.p.4">HTML representations implement most ALPS elements using HTML's 'class' attribute. The 'collection' ID has become the CSS class of an HTML form's submit button.  The 'contact' ID has become the CSS class of the TR elements in an HTML table. The subordinate descriptors 'fullname','email', and 'phone' are rendered as the TD elements of each TR.  </p>
 <p id="rfc.section.1.3.p.5">This HAL document uses the same profile to express the same application-level semantics as the HTML document.  </p>
 <pre>
 &lt;resource href="http://example.org/contacts/"&gt;
@@ -667,7 +667,7 @@
 &lt;/resource&gt;
                     </pre>
 <p class="figure">HAL XML Contacts Representation</p>
-<p id="rfc.section.1.3.p.6">In a HAL representation, all state transitions ("collection" and "item", in this case) are represented as link relations. All data descriptors ("fullName", "email", and "phone") are represented as XML tags named after the descriptors.  </p>
+<p id="rfc.section.1.3.p.6">In a HAL representation, all state transitions ('collection' and 'item', in this case) are represented as link relations. All data descriptors ('fullName', 'email', and 'phone') are represented as XML tags named after the descriptors.  </p>
 <p id="rfc.section.1.3.p.7">This Collection+JSON document uses the ALPS profile to express the same application-level semantics as the HTML and HAL documents.  </p>
 <pre>
 {
@@ -749,18 +749,18 @@
                 
                </pre>
 <p class="figure">Collection+JSON Contacts Representation</p>
-<p id="rfc.section.1.3.p.8">The descriptor "collection" has become the link relation associated with a Collection+JSON query. The descriptors "fullName", "email", and "phone" have become the names of key-value pairs in the items in a Collection+JSON collection.  </p>
+<p id="rfc.section.1.3.p.8">The descriptor 'collection' has become the link relation associated with a Collection+JSON query. The descriptors 'fullName', 'email', and 'phone' have become the names of key-value pairs in the items in a Collection+JSON collection.  </p>
 <h1 id="rfc.section.1.4"><a href="#rfc.section.1.4">1.4.</a> Identifying an ALPS Document</h1>
 <p id="rfc.section.1.4.p.1">An ALPS vocabulary is identified by a unique URL.  This URL SHOULD be assumed to be dereferencable.  All ALPS URLs MUST be unique and all ALPS documents intended for public consumption SHOULD be registered in an ALPS Registry [TK: add text on where/how to find registries -mamund].  </p>
 <p id="rfc.section.1.4.p.2">In order to reduce load on servers responding to ALPS document requests, it is RECOMMENDED that servers use cache control directives that instruct client apps to locally cache the results. Clients making these ALPS document requests SHOULD honor the server's caching directives.  </p>
 <h1 id="rfc.section.2"><a href="#rfc.section.2">2.</a> ALPS Documents</h1>
 <p id="rfc.section.2.p.1">An ALPS document contains a machine-readable collection of identifying strings and their human-readable explanations. An ALPS document can be represented in either XML or JSON format. This section identifies the general elements and properties of an ALPS document, their meaning, and their use, independent of how the document is represented.  <a href="#representations">Section 2.3</a> provides specific details on constructing a valid ALPS document in XML and in JSON format.  </p>
 <h1 id="rfc.section.2.1"><a href="#rfc.section.2.1">2.1.</a> Compliance</h1>
-<p id="rfc.section.2.1.p.1">An implementation is not compliant if it fails to satisfy one or more of the MUST or REQUIRED level requirements. An implementation that satisfies all the MUST or REQUIRED level and all the SHOULD level requirements is said to be "unconditionally compliant"; one that satisfies all the MUST level requirements but not all the SHOULD level requirements is said to be "conditionally compliant." </p>
+<p id="rfc.section.2.1.p.1">An implementation is not compliant if it fails to satisfy one or more of the MUST or REQUIRED level requirements. An implementation that satisfies all the MUST or REQUIRED level and all the SHOULD level requirements is said to be 'unconditionally compliant'; one that satisfies all the MUST level requirements but not all the SHOULD level requirements is said to be 'conditionally compliant.' </p>
 <h1 id="rfc.section.2.2"><a href="#rfc.section.2.2">2.2.</a> ALPS Document Properties</h1>
 <p id="rfc.section.2.2.p.1">The ALPS media type defines a small set of properties. These properties appear in both the XML and JSON formats. Below is a list of the properties that can appear in an ALPS document.  </p>
 <h1 id="rfc.section.2.2.1"><a href="#rfc.section.2.2.1">2.2.1.</a> <a href="#prop-alps" id="prop-alps">'alps'</a></h1>
-<p id="rfc.section.2.2.1.p.1">Indicates the root of the ALPS document. This property is REQUIRED, and it SHOULD have one or more <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite> child properties.  </p>
+<p id="rfc.section.2.2.1.p.1">Indicates the root of the ALPS document. This property is REQUIRED, and it SHOULD have one or more <a href="#prop-descriptor">'descriptor'</a> child properties.  </p>
 <p id="rfc.section.2.2.1.p.2">Examples: </p>
 
 <dl>
@@ -772,7 +772,7 @@
 
 <p> </p>
 <h1 id="rfc.section.2.2.2"><a href="#rfc.section.2.2.2">2.2.2.</a> <a href="#prop-doc" id="prop-doc">'doc'</a></h1>
-<p id="rfc.section.2.2.2.p.1">A text field that contains free-form, usually human-readable, text.  The 'doc' element MAY have two properties: <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> and <a href="#prop-format">'format'</a> <cite title="NONE">[prop-format]</cite>.  If the 'href' property appears it SHOULD contain a dereferencable URL that points to human-readable text. If the 'format' property appears it SHOULD contain one of the following values: "text", "html", "asciidoc", or "markdown".  Any program processing "doc" elements SHOULD honor the "format" directive and parse/render the content appropriately. If the value in the "format" property is not recognized and/or supported, the processing program MUST treat the content as plain text. If no 'format' property is present, the content SHOULD be treated as plain text.  </p>
+<p id="rfc.section.2.2.2.p.1">A text field that contains free-form, usually human-readable, text.  The 'doc' element MAY have two properties: <a href="#prop-href">'href'</a> and <a href="#prop-format">'format'</a>.  If the 'href' property appears it SHOULD contain a dereferencable URL that points to human-readable text. If the 'format' property appears it SHOULD contain one of the following values: 'text', 'html', 'asciidoc', or 'markdown'.  Any program processing 'doc' elements SHOULD honor the 'format' directive and parse/render the content appropriately. If the value in the 'format' property is not recognized and/or supported, the processing program MUST treat the content as plain text. If no 'format' property is present, the content SHOULD be treated as plain text.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -782,7 +782,7 @@
 </dl>
 
 <p> </p>
-<p id="rfc.section.2.2.2.p.2">A 'doc' element SHOULD appear as a child of <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>. When present, it describes the meaning and use of the related 'descriptor'.  </p>
+<p id="rfc.section.2.2.2.p.2">A 'doc' element SHOULD appear as a child of <a href="#prop-descriptor">'descriptor'</a>. When present, it describes the meaning and use of the related 'descriptor'.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -792,7 +792,7 @@
 </dl>
 
 <p> </p>
-<p id="rfc.section.2.2.2.p.3">The 'doc' element MAY appear as a child of <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite>. When present, it describes the purpose of the ALPS document as a whole.  </p>
+<p id="rfc.section.2.2.2.p.3">The 'doc' element MAY appear as a child of <a href="#prop-alps">'alps'</a>. When present, it describes the purpose of the ALPS document as a whole.  </p>
 
 <dl>
   <dt>XML:</dt>
@@ -804,14 +804,14 @@
 <p> </p>
 <h1 id="rfc.section.2.2.3"><a href="#rfc.section.2.2.3">2.2.3.</a> <a href="#prop-descriptor" id="prop-descriptor">'descriptor'</a></h1>
 <p id="rfc.section.2.2.3.p.1">A 'descriptor' element defines the semantics of specific data elements or state transitions that MAY exist in an associated representation.  </p>
-<p id="rfc.section.2.2.3.p.2">One or more 'descriptor' elements SHOULD appear as children of <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite>. It may also appear as a child of itself; that is, the 'descriptor' property may be nested.  </p>
-<p id="rfc.section.2.2.3.p.3">The 'descriptor' property SHOULD have either an <a href="#prop-id">'id'</a> <cite title="NONE">[prop-id]</cite> or <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> attribute. It MAY have both. Additionally, the 'descriptor' MAY have any of the following attributes: </p>
+<p id="rfc.section.2.2.3.p.2">One or more 'descriptor' elements SHOULD appear as children of <a href="#prop-alps">'alps'</a>. It may also appear as a child of itself; that is, the 'descriptor' property may be nested.  </p>
+<p id="rfc.section.2.2.3.p.3">The 'descriptor' property SHOULD have either an <a href="#prop-id">'id'</a> or <a href="#prop-href">'href'</a> attribute. It MAY have both. Additionally, the 'descriptor' MAY have any of the following attributes: </p>
 
 <ol>
-  <li><a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> </li>
-  <li><a href="#prop-ext">'ext'</a> <cite title="NONE">[prop-ext]</cite> </li>
-  <li><a href="#prop-name">'name'</a> <cite title="NONE">[prop-name]</cite> </li>
-  <li><a href="#prop-type">'type'</a> <cite title="NONE">[prop-type]</cite> </li>
+  <li><a href="#prop-doc">'doc'</a> </li>
+  <li><a href="#prop-ext">'ext'</a> </li>
+  <li><a href="#prop-name">'name'</a> </li>
+  <li><a href="#prop-type">'type'</a> </li>
 </ol>
 
 <p> </p>
@@ -842,13 +842,13 @@
 <p id="rfc.section.2.2.4.p.2">The 'ext' element has the following properties.  </p>
 
 <ol>
-  <li><a href="#prop-id">id</a> <cite title="NONE">[prop-id]</cite> </li>
-  <li><a href="#prop-href">href</a> <cite title="NONE">[prop-href]</cite> </li>
-  <li><a href="#prop-value">value</a> <cite title="NONE">[prop-value]</cite> </li>
+  <li><a href="#prop-id">'id'</a> </li>
+  <li><a href="#prop-href">'href'</a> </li>
+  <li><a href="#prop-value">'value'</a> </li>
 </ol>
 
 <p> </p>
-<p id="rfc.section.2.2.4.p.3">The <a href="#prop-id">id</a> <cite title="NONE">[prop-id]</cite> property is REQUIRED.  The <a href="#prop-href">href</a> <cite title="NONE">[prop-href]</cite> is RECOMMENDED and it SHOULD point to documentation that explains the use and meaning of this <a href="#prop-ext">ext</a> <cite title="NONE">[prop-ext]</cite> element.  The <a href="#prop-value">value</a> <cite title="NONE">[prop-value]</cite> property is OPTIONAL. The content is undetermined; its meaning and use SHOULD be explained by the document found by de-referencing the <a href="#prop-href">href</a> <cite title="NONE">[prop-href]</cite> property.  </p>
+<p id="rfc.section.2.2.4.p.3">The <a href="#prop-id">'id'</a> property is REQUIRED.  The <a href="#prop-href">'href'</a> is RECOMMENDED and it SHOULD point to documentation that explains the use and meaning of this <a href="#prop-ext">'ext'</a> element.  The <a href="#prop-value">'value'</a> property is OPTIONAL. The content is undetermined; its meaning and use SHOULD be explained by the document found by de-referencing the <a href="#prop-href">'href'</a> property.  </p>
 <p id="rfc.section.2.2.4.p.4">Examples: </p>
 
 <dl>
@@ -862,33 +862,33 @@
 <p id="rfc.section.2.2.4.p.5">The 'ext' element MAY appear as a child of the following elements: </p>
 
 <ol>
-  <li><a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite> </li>
-  <li><a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite> </li>
+  <li><a href="#prop-alps">'alps'</a> </li>
+  <li><a href="#prop-descriptor">'descriptor'</a> </li>
 </ol>
 
 <p> </p>
 <p id="rfc.section.2.2.4.p.6">Since the 'ext' element has no specific meaning within this specification, it MUST be ignored by any application that does not understand its meaning.  </p>
 <h1 id="rfc.section.2.2.5"><a href="#rfc.section.2.2.5">2.2.5.</a> <a href="#prop-format" id="prop-format">'format'</a></h1>
-<p id="rfc.section.2.2.5.p.1">Indicates how the text content should be parsed and/or rendered. This specification identifies a range of possible values for "format": </p>
+<p id="rfc.section.2.2.5.p.1">Indicates how the text content should be parsed and/or rendered. This specification identifies a range of possible values for 'format': </p>
 
 <ul>
-  <li>"text", for plain text, MUST be supported.</li>
-  <li>"html", for HTML, SHOULD be supported.</li>
-  <li>"asciidoc", for AsciiDoc, MAY be supported.</li>
-  <li>"markdown", per <a href="#draft-ietf-appsawg-text-markdown-05">The text/markdown Media Type</a> <cite title="NONE">[draft-ietf-appsawg-text-markdown-05]</cite>, MAY be supported.</li>
+  <li>'text', for plain text, MUST be supported.</li>
+  <li>'html', for HTML, SHOULD be supported.</li>
+  <li>'asciidoc', for AsciiDoc, MAY be supported.</li>
+  <li>'markdown', per <a href="#I-D.ietf-appsawg-text-markdown">The text/markdown Media Type</a> <cite title="NONE">[I-D.ietf-appsawg-text-markdown]</cite>, MAY be supported.</li>
 </ul>
 
-<p> Any other values for this attribute are undefined and SHOULD be treated as plain text. If the program does not recognize the value of the "format" property and/or the "format" property is missing, the content SHOULD be treated as plain text.  </p>
-<p id="rfc.section.2.2.5.p.2">This property MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> element.  </p>
+<p> Any other values for this attribute are undefined and SHOULD be treated as plain text. If the program does not recognize the value of the 'format' property and/or the 'format' property is missing, the content SHOULD be treated as plain text.  </p>
+<p id="rfc.section.2.2.5.p.2">This property MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> element.  </p>
 <h1 id="rfc.section.2.2.6"><a href="#rfc.section.2.2.6">2.2.6.</a> <a href="#prop-href" id="prop-href">'href'</a></h1>
 <p id="rfc.section.2.2.6.p.1">Contains a resolvable URL.  </p>
-<p id="rfc.section.2.2.6.p.2">When it appears as an attribute of a <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>, 'href' points to another 'descriptor' either within the existing ALPS document as a fragment or in another ALPS document as an absolute URL. The URL MUST contain a <a href="#prop-id-frag">fragment</a> <cite title="NONE">[prop-id-frag]</cite> referencing the related 'descriptor'.  </p>
-<p id="rfc.section.2.2.6.p.3">When it appears as an attribute of <a href="#prop-ext">'ext'</a> <cite title="NONE">[prop-ext]</cite>, 'href' points to an external document which provides the defintion of the extension.  </p>
-<p id="rfc.section.2.2.6.p.4">When it appears as an attribute of <a href="#prop-link">'link'</a> <cite title="NONE">[prop-link]</cite>, 'href' points to an external document whose relationship to the current document or 'descriptor' is described by the associated <a href="#prop-rel">'rel'</a> <cite title="NONE">[prop-rel]</cite> property.  </p>
-<p id="rfc.section.2.2.6.p.5">When it appears as an attribute of <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite>, 'href' points to a document that contains human-readable text that describes the associated 'descriptor' or ALPS document.  </p>
+<p id="rfc.section.2.2.6.p.2">When it appears as an attribute of a <a href="#prop-descriptor">'descriptor'</a>, 'href' points to another 'descriptor' either within the existing ALPS document as a fragment or in another ALPS document as an absolute URL. The URL MUST contain a fragment per <a href="#prop-id-frag">Section 2.2.7.2</a> referencing the related 'descriptor'.  </p>
+<p id="rfc.section.2.2.6.p.3">When it appears as an attribute of <a href="#prop-ext">'ext'</a>, 'href' points to an external document which provides the defintion of the extension.  </p>
+<p id="rfc.section.2.2.6.p.4">When it appears as an attribute of <a href="#prop-link">'link'</a>, 'href' points to an external document whose relationship to the current document or 'descriptor' is described by the associated <a href="#prop-rel">'rel'</a> property.  </p>
+<p id="rfc.section.2.2.6.p.5">When it appears as an attribute of <a href="#prop-doc">'doc'</a>, 'href' points to a document that contains human-readable text that describes the associated 'descriptor' or ALPS document.  </p>
 <h1 id="rfc.section.2.2.7"><a href="#rfc.section.2.2.7">2.2.7.</a> <a href="#prop-id" id="prop-id">'id'</a></h1>
-<p id="rfc.section.2.2.7.p.1">A document-wide unique identifier for the related element. This SHOULD appear as an attribute of a <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>.  </p>
-<p id="rfc.section.2.2.7.p.2">The value of this attribute MAY be used as an identifier in the related runtime hypermedia representation. In the example below the ALPS descriptor with an 'id' of "q" is used to identify an HTML input element: </p>
+<p id="rfc.section.2.2.7.p.1">A document-wide unique identifier for the related element. This SHOULD appear as an attribute of a <a href="#prop-descriptor">'descriptor'</a>.  </p>
+<p id="rfc.section.2.2.7.p.2">The value of this attribute MAY be used as an identifier in the related runtime hypermedia representation. In the example below the ALPS descriptor with an 'id' of 'q' is used to identify an HTML input element: </p>
 
 <dl>
   <dt>'id' in ALPS...</dt>
@@ -906,7 +906,7 @@
 <p id="rfc.section.2.2.7.p.3">It should be noted that the exact mapping from ALPS elements (e.g. 'id') to elements within a particular media type (HTML, Collection+JSON, etc.) is covered in separate documents (to be specified).  </p>
 <h1 id="rfc.section.2.2.7.1"><a href="#rfc.section.2.2.7.1">2.2.7.1.</a> <a href="#prop-id-name" id="prop-id-name">ALPS 'id' and 'name' Properties</a></h1>
 <p id="rfc.section.2.2.7.1.p.1">In some cases, media types support non-unique identifiers (e.g. HTML's 'name' property) or will allow the same identifier value for multiple elements in the same representation (e.g. &lt;div id="search" ... /&gt; and &lt;input type="submit" class="search" .../&gt; and &lt;input name="search" ... /&gt;). In those cases, translating that representation into ALPS documents could result in multiple 'id' properties with the same value.  </p>
-<p id="rfc.section.2.2.7.1.p.2">To avoid this, ALPS document designers can add the <a href="#prop-name">name</a> <cite title="NONE">[prop-name]</cite> property to a 'descriptor' to hold the common value ("search") while still using the <a href="#prop-id">id</a> <cite title="NONE">[prop-id]</cite> property to hold a document-wide unique value. For example: </p>
+<p id="rfc.section.2.2.7.1.p.2">To avoid this, ALPS document designers can add the <a href="#prop-name">'name'</a> property to a 'descriptor' to hold the common value ('search') while still using the <a href="#prop-id">'id'</a> property to hold a document-wide unique value. For example: </p>
 <pre>
 &lt;!-- HTML --&gt;
 &lt;div id="search"&gt;
@@ -927,45 +927,45 @@
           </pre>
 <p class="figure">ALPS Description of the same Search Transition</p>
 <h1 id="rfc.section.2.2.7.2"><a href="#rfc.section.2.2.7.2">2.2.7.2.</a> <a href="#prop-id-frag" id="prop-id-frag">Fragment Identifiers and 'id'</a></h1>
-<p id="rfc.section.2.2.7.2.p.1">When applied to an ALPS document, a URI fragment identifier points to the 'descriptor' whose 'id' is the value of the fragment. For example, the fragment identifier "customer" in the URI http://example.com/my-alps-document#customer refers to an ALPS 'descriptor' with 'id' set to "customer".  </p>
+<p id="rfc.section.2.2.7.2.p.1">When applied to an ALPS document, a URI fragment identifier points to the 'descriptor' whose 'id' is the value of the fragment. For example, the fragment identifier 'customer' in the URI http://example.com/my-alps-document#customer refers to an ALPS 'descriptor' with 'id' set to 'customer'.  </p>
 <p id="rfc.section.2.2.7.2.p.2">A relative URL with a fragment identifier within an ALPS document (e.g. href="#customer") refers to a local 'descriptor' within the document containing the reference.  </p>
-<p id="rfc.section.2.2.7.2.p.3">The complete URI to an ALPS 'descriptor' (including the fragment) forms an "abstract semantic type" identifier. This is a resolvable URI (URL) that can be used to indicate the type of a resource; for instance, it can be used as the value of the IANA-registered relation type 'type'.  </p>
+<p id="rfc.section.2.2.7.2.p.3">The complete URI to an ALPS 'descriptor' (including the fragment) forms an 'abstract semantic type' identifier. This is a resolvable URI (URL) that can be used to indicate the type of a resource; for instance, it can be used as the value of the IANA-registered relation type 'type'.  </p>
 <h1 id="rfc.section.2.2.7.3"><a href="#rfc.section.2.2.7.3">2.2.7.3.</a> <a href="#prop-id-rels" id="prop-id-rels">Link Relation Values and 'id' or 'name'</a></h1>
 <p id="rfc.section.2.2.7.3.p.1">Since a state transition 'descriptor' may define a relation type value, it is important to avoid creating conflicts with existing IANA-registered values. If the resulting link relation type is the same as a registered relation type, the descriptor MUST not change the meaning of the IANA relation type.  </p>
 <p id="rfc.section.2.2.7.3.p.2">Further, since the 'id' of a 'descriptor' may define a link relation value per <a href="#prop-descriptor-link-relations">Section 2.2.3.1</a>, if a conflict exists in defining such a descriptor's document-wide unique 'id' with another 'descriptor', the conflicting 'descriptor' MUST define a unique 'id' and MAY specify a 'name' property to resolve the conflict.  </p>
 <p id="rfc.section.2.2.7.3.p.3">If it is unclear whether a registered link relation type in a representation document refers to a relation registered with IANA or a relation registered in an ALPS profile, the semantics of that link are undefined.  </p>
 <h1 id="rfc.section.2.2.8"><a href="#rfc.section.2.2.8">2.2.8.</a> <a href="#prop-link" id="prop-link">'link'</a></h1>
-<p id="rfc.section.2.2.8.p.1">An element that identifies a link between the current ALPS element and some other (possibly external) resource. MAY be a child element of the <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite> and the <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite> elements.  </p>
-<p id="rfc.section.2.2.8.p.2">The 'link' element MUST define the two attributes <a href="#prop-href">'href'</a> <cite title="NONE">[prop-href]</cite> and <a href="#prop-rel">'rel'</a> <cite title="NONE">[prop-rel]</cite>.  </p>
+<p id="rfc.section.2.2.8.p.1">An element that identifies a link between the current ALPS element and some other (possibly external) resource. MAY be a child element of the <a href="#prop-alps">'alps'</a> and the <a href="#prop-descriptor">'descriptor'</a> elements.  </p>
+<p id="rfc.section.2.2.8.p.2">The 'link' element MUST define the two attributes <a href="#prop-href">'href'</a> and <a href="#prop-rel">'rel'</a>.  </p>
 <h1 id="rfc.section.2.2.9"><a href="#rfc.section.2.2.9">2.2.9.</a> <a href="#prop-name" id="prop-name">'name'</a></h1>
-<p id="rfc.section.2.2.9.p.1">Indicates the name of the <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite> as found in generic representations. It MAY appear as a property of 'descriptor'.  </p>
-<p id="rfc.section.2.2.9.p.2">This is used when the name of the 'descriptor' is used as an <a href="#prop-id">'id'</a> <cite title="NONE">[prop-id]</cite> value elsewhere in the ALPS document. For instance, if a single ALPS document defines a semantic descriptor (data element) called "customer" and a safe descriptor (transition element) also called "customer", they cannot both have 'id="customer"' in the ALPS document. One of them needs to have some other 'id', and to set 'name="customer"'.  </p>
+<p id="rfc.section.2.2.9.p.1">Indicates the name of the <a href="#prop-descriptor">'descriptor'</a> as found in generic representations. It MAY appear as a property of 'descriptor'.  </p>
+<p id="rfc.section.2.2.9.p.2">This is used when the name of the 'descriptor' is used as an <a href="#prop-id">'id'</a> value elsewhere in the ALPS document. For instance, if a single ALPS document defines a semantic descriptor (data element) called 'customer' and a safe descriptor (transition element) also called 'customer', they cannot both have 'id="customer"' in the ALPS document. One of them needs to have some other 'id', and to set 'name="customer"'.  </p>
 <p id="rfc.section.2.2.9.p.3">The use of the 'name' property usually indicates an ambiguity in the application semantics. Thus, it SHOULD only be used when creating an ALPS profile that describes an existing design.  </p>
 <h1 id="rfc.section.2.2.10"><a href="#rfc.section.2.2.10">2.2.10.</a> <a href="#prop-rel" id="prop-rel">'rel'</a></h1>
 <p id="rfc.section.2.2.10.p.1">Contains a <a href="#RFC5988">[RFC5988]</a> approved value: either an extension relation type (a URI) or a registered relation type (a short string).  </p>
-<p id="rfc.section.2.2.10.p.2">Appears as a property of<a href="#prop-link">link</a> <cite title="NONE">[prop-link]</cite>.  </p>
+<p id="rfc.section.2.2.10.p.2">Appears as a property of<a href="#prop-link">'link'</a>.  </p>
 <h1 id="rfc.section.2.2.11"><a href="#rfc.section.2.2.11">2.2.11.</a> <a href="#prop-rt" id="prop-rt">'rt'</a></h1>
-<p id="rfc.section.2.2.11.p.1">Indicates the resource type that will be returned when executing the specified network request. The 'rt' attribute SHOULD appear only on a <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite> with a <a href="#prop-type">'type'</a> <cite title="NONE">[prop-type]</cite> value of 'safe', 'unsafe', or 'idempotent.' </p>
-<p id="rfc.section.2.2.11.p.2">The 'rt' attribute is OPTIONAL and is an opaque string and MAY match the <a href="#prop-id">'id'</a> <cite title="NONE">[prop-id]</cite> of an existing<a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>.  </p>
+<p id="rfc.section.2.2.11.p.1">Indicates the resource type that will be returned when executing the specified network request. The 'rt' attribute SHOULD appear only on a <a href="#prop-descriptor">'descriptor'</a> with a <a href="#prop-type">'type'</a> value of 'safe', 'unsafe', or 'idempotent.' </p>
+<p id="rfc.section.2.2.11.p.2">The 'rt' attribute is OPTIONAL and is an opaque string and MAY match the <a href="#prop-id">'id'</a> of an existing<a href="#prop-descriptor">'descriptor'</a>.  </p>
 <h1 id="rfc.section.2.2.12"><a href="#rfc.section.2.2.12">2.2.12.</a> <a href="#prop-type" id="prop-type">'type'</a></h1>
-<p id="rfc.section.2.2.12.p.1">Indicates the type of hypermedia control to which the element is applied within the resulting representation.  This SHOULD appear for each <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite> element.  The four valid values are: </p>
+<p id="rfc.section.2.2.12.p.1">Indicates the type of hypermedia control to which the element is applied within the resulting representation.  This SHOULD appear for each <a href="#prop-descriptor">'descriptor'</a> element.  The four valid values are: </p>
 
 <dl>
-  <dt>"semantic"</dt>
+  <dt>'semantic'</dt>
   <dd style="margin-left: 8">A state element (e.g. HTML.SPAN, HTML.INPUT, etc.).  </dd>
-  <dt>"safe"</dt>
+  <dt>'safe'</dt>
   <dd style="margin-left: 8">A hypermedia control that triggers a safe, idempotent state transition (e.g. HTTP.GET or HTTP.HEAD).  </dd>
-  <dt>"idempotent"</dt>
+  <dt>'idempotent'</dt>
   <dd style="margin-left: 8">A hypermedia control that triggers an unsafe, idempotent state transition (e.g. HTTP.PUT or HTTP.DELETE).  </dd>
-  <dt>"unsafe"</dt>
+  <dt>'unsafe'</dt>
   <dd style="margin-left: 8">A hypermedia control that triggers an unsafe, non-idempotent state transition (e.g. HTTP.POST).  </dd>
 </dl>
 
 <p> If no 'type' attribute is associated with the element, then 'type="semantic"' is implied.  </p>
 <h1 id="rfc.section.2.2.13"><a href="#rfc.section.2.2.13">2.2.13.</a> <a href="#prop-value" id="prop-value">'value'</a></h1>
-<p id="rfc.section.2.2.13.p.1">Contains a string value. It MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> and the <a href="#prop-ext">'ext'</a> <cite title="NONE">[prop-ext]</cite> elements.  </p>
+<p id="rfc.section.2.2.13.p.1">Contains a string value. It MAY appear as an attribute of the <a href="#prop-doc">'doc'</a> and the <a href="#prop-ext">'ext'</a> elements.  </p>
 <h1 id="rfc.section.2.2.14"><a href="#rfc.section.2.2.14">2.2.14.</a> <a href="#prop-version" id="prop-version">'version'</a></h1>
-<p id="rfc.section.2.2.14.p.1">Indicates the version of the ALPS specification used in the document. This SHOULD appear as a property of the <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite> element.  Currently the only valid value is "1.0". If no value appears, then 'version="1.0"' is implied.  </p>
+<p id="rfc.section.2.2.14.p.1">Indicates the version of the ALPS specification used in the document. This SHOULD appear as a property of the <a href="#prop-alps">'alps'</a> element.  Currently the only valid value is '1.0'. If no value appears, then 'version="1.0"' is implied.  </p>
 <h1 id="rfc.section.2.3"><a href="#rfc.section.2.3">2.3.</a> <a href="#representations" id="representations">ALPS Representations</a></h1>
 <p id="rfc.section.2.3.p.1">An ALPS document may be represented in either XML or JSON format. This section contains notes on how the ALPS elements and attributes appear in each format, along with examples to guide ALPS document authors.  </p>
 <h1 id="rfc.section.2.3.1"><a href="#rfc.section.2.3.1">2.3.1.</a> <a href="#html-representation" id="html-representation">Sample HTML</a></h1>
@@ -990,7 +990,7 @@
 <p class="figure">HTML Sample</p>
 <p id="rfc.section.2.3.1.p.1">Below is a simple HTML document that contains a handful of semantic descriptors and transition instructions.  This document was generated from the XML and JSON ALPS documents that follow. Use this HTML document as a guide when evaluating the XML and JSON examples.  </p>
 <h1 id="rfc.section.2.3.2"><a href="#rfc.section.2.3.2">2.3.2.</a> <a href="#xml-representation" id="xml-representation">XML Representation Example</a></h1>
-<p id="rfc.section.2.3.2.p.1">In the XML version of an ALPS document, the following ALPS properties always appear as XML elements: <a href="#prop-alps">'alps'</a> <cite title="NONE">[prop-alps]</cite>, <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite>, <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite>, and <a href="#prop-ext">'ext'</a> <cite title="NONE">[prop-ext]</cite>. All other ALPS properties appear as XML attributes.  </p>
+<p id="rfc.section.2.3.2.p.1">In the XML version of an ALPS document, the following ALPS properties always appear as XML elements: <a href="#prop-alps">'alps'</a>, <a href="#prop-doc">'doc'</a>, <a href="#prop-descriptor">'descriptor'</a>, and <a href="#prop-ext">'ext'</a>. All other ALPS properties appear as XML attributes.  </p>
 <h1 id="rfc.section.2.3.2.1"><a href="#rfc.section.2.3.2.1">2.3.2.1.</a> Complete XML Representation</h1>
 <p id="rfc.section.2.3.2.1.p.1">Below is an example of an application/alps+xml representation.  </p>
 <pre>
@@ -1016,7 +1016,7 @@
                           </pre>
 <p class="figure">Complete XML Representation</p>
 <h1 id="rfc.section.2.3.3"><a href="#rfc.section.2.3.3">2.3.3.</a> <a href="#json-representation" id="json-representation">JSON Representation Example</a></h1>
-<p id="rfc.section.2.3.3.p.1">When representing ALPS documents in JSON format, the <a href="#prop-descriptor">'descriptor'</a> <cite title="NONE">[prop-descriptor]</cite> and <a href="#prop-ext">'ext'</a> <cite title="NONE">[prop-ext]</cite> properties are always expressed as arrays of anonymous objects - even when there is only one member in the array.  </p>
+<p id="rfc.section.2.3.3.p.1">When representing ALPS documents in JSON format, the <a href="#prop-descriptor">'descriptor'</a> and <a href="#prop-ext">'ext'</a> properties are always expressed as arrays of anonymous objects - even when there is only one member in the array.  </p>
 
 <p>For example:</p>
 <pre>
@@ -1031,7 +1031,7 @@
 ]
               </pre>
 <p class="figure">Arrays in ALPS+JSON</p>
-<p id="rfc.section.2.3.3.p.2">The <a href="#prop-doc">'doc'</a> <cite title="NONE">[prop-doc]</cite> property is always expressed as a named object.  </p>
+<p id="rfc.section.2.3.3.p.2">The <a href="#prop-doc">'doc'</a> property is always expressed as a named object.  </p>
 <p/>
 
 <p>For example:</p>
@@ -1091,7 +1091,7 @@
 <p/>
 <p id="rfc.section.3.p.3">Not all media types can faithfully represent all ALPS descriptors. For instance, the 'application/json' media type has no standard way of representing hyperlinks. The [details of how to apply ALPS to such a media type will necesarily be incomplete, and it will not be possible to represent some aspects of an ALPS profile in documents in that media type.  </p>
 <h1 id="rfc.section.3.1"><a href="#rfc.section.3.1">3.1.</a> <a href="#linking-to-alps-documents" id="linking-to-alps-documents">Linking to ALPS Documents</a></h1>
-<p id="rfc.section.3.1.p.1">To indicate that an ALPS profile describes the semantics of some representation document, the representation document SHOULD be linked to the ALPS document. The "profile" link relation <a href="#RFC6906">[RFC6906]</a> MUST be used when creating this link.  If the media type of the representation document has no native ability to link to other resources, or no ability to express link relations, the HTTP header 'Link' <a href="#RFC5988">[RFC5988]</a> MAY be used to connect the representation document and the ALPS profile. If the media type of the representation document defines a parameter for linking the document to a profile, that parameter MAY be used to connect the representation document and the ALPS profile.  </p>
+<p id="rfc.section.3.1.p.1">To indicate that an ALPS profile describes the semantics of some representation document, the representation document SHOULD be linked to the ALPS document. The 'profile' link relation <a href="#RFC6906">[RFC6906]</a> MUST be used when creating this link.  If the media type of the representation document has no native ability to link to other resources, or no ability to express link relations, the HTTP header 'Link' <a href="#RFC5988">[RFC5988]</a> MAY be used to connect the representation document and the ALPS profile. If the media type of the representation document defines a parameter for linking the document to a profile, that parameter MAY be used to connect the representation document and the ALPS profile.  </p>
 <p id="rfc.section.3.1.p.2">A single representation document may be described by more than one ALPS profile. If two ALPS profiles give conflicting semantics for the same element, the document linked to earlier in the representation SHOULD take precedence. A profile linked to using the 'Link' header takes precedence over a profile linked to within the representation document itself. A profile linked to using a media type parameter takes precedence over a profile linked to using the 'Link' header and a profile linked to within the representation document itself.  </p>
 <h1 id="rfc.section.4"><a href="#rfc.section.4">4.</a> <a href="#iana-considerations" id="iana-considerations">IANA Considerations</a></h1>
 <p id="rfc.section.4.p.1">This specification establishes two media types: 'application/alps+xml' and 'application/alps+json' </p>
@@ -1260,6 +1260,12 @@
       </td>
       <td class="top"><a>Wilde, E.</a>, "<a href="http://tools.ietf.org/html/rfc6906">The 'profile' Link Relation Type</a>", RFC 6906, March 2013.</td>
     </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC7320">[RFC7320]</b>
+      </td>
+      <td class="top"><a>Nottingham, M.</a>, "<a href="http://tools.ietf.org/html/rfc7320">URI Design and Ownership</a>", BCP 190, RFC 7320, July 2014.</td>
+    </tr>
   </tbody>
 </table>
 <h1 id="rfc.references.2"><a href="#rfc.references.2">7.2.</a> Informative References</h1>
@@ -1267,26 +1273,20 @@
   <tbody>
     <tr>
       <td class="reference">
-        <b id="draft-ietf-appsawg-uri-get-off-my-lawn-00">[draft-ietf-appsawg-uri-get-off-my-lawn-00]</b>
+        <b id="I-D.ietf-appsawg-text-markdown">[I-D.ietf-appsawg-text-markdown]</b>
       </td>
-      <td class="top"><a>Nottingham, M.</a>, "<a>Standardising Structure in URIs</a>", I-D draft-ietf-appsawg-uri-get-off-my-lawn-00, September 2013.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="draft-ietf-appsawg-text-markdown-05">[draft-ietf-appsawg-text-markdown-05]</b>
-      </td>
-      <td class="top"><a>Leonard, S.</a>, "<a>The text/markdown Media Type</a>", I-D draft-ietf-appsawg-text-markdown-05, December 2014.</td>
+      <td class="top"><a>Leonard, S.</a>, "<a href="http://tools.ietf.org/html/draft-ietf-appsawg-text-markdown-05">The text/markdown Media Type</a>", Internet-Draft draft-ietf-appsawg-text-markdown-05, December 2014.</td>
     </tr>
   </tbody>
 </table>
 <h1 id="rfc.appendix.A"><a href="#rfc.appendix.A">Appendix A.</a> Frequently Asked Questions</h1>
 <h1 id="rfc.appendix.A.1"><a href="#rfc.appendix.A.1">A.1.</a> Why are there no URLs in ALPS?</h1>
-<p id="rfc.section.A.1.p.1">ALPS is meant to describe a service in a universal way. The same ALPS description document can be used by many ALPS-compliant servers. Since each service implementation is in charge of their own URL space, ALPS descriptions do not include URLs.  See <a href="#draft-ietf-appsawg-uri-get-off-my-lawn-00">Standardising Structure in URIs</a> <cite title="NONE">[draft-ietf-appsawg-uri-get-off-my-lawn-00]</cite> for more on this principle.  </p>
+<p id="rfc.section.A.1.p.1">ALPS is meant to describe a service in a universal way. The same ALPS description document can be used by many ALPS-compliant servers. Since each service implementation is in charge of their own URL space, ALPS descriptions do not include URLs.  See <a href="#RFC7320">URI Design and Ownership</a> <cite title="NONE">[RFC7320]</cite> for more on this principle.  </p>
 <p id="rfc.section.A.1.p.2">When implementing ALPS-compliant servers, implementors are free to use any URL design they wish.  All that is required is that implementors use the same ALPS profile descriptor 'id' and 'name' properties in the representations. When implementing ALPS-compliant client applications, the URLs will be supplied at runtime by the server represetentations. Client apps only need to recognize the descriptor 'id' and 'name' values from the referenced ALPS profile document.  </p>
 <h1 id="rfc.appendix.A.2"><a href="#rfc.appendix.A.2">A.2.</a> Why is there no workflow component in the ALPS specification?</h1>
-<p id="rfc.section.A.2.p.1">ALPS is not designed to describe workflows or execution paths for a service. Instead, ALPS is designed to describe a shared set of data and actions elements that server MAY implement in order to create a service. Each action descriptor (where the descriptor's type property is set to "safe", "unsafe", or "idemponent") SHOULD describe a state transition that a ALPS-compliant client application can invoke when it is available. Servers are free to implement the transitions they find useful and to arrange them in any order they wish.  ALPS-compliant client applications SHOULD be able to recognize these descriptors when they appear and are free to act upon them directly, render them for humans to invoke, or ignore/hide them completely.  </p>
+<p id="rfc.section.A.2.p.1">ALPS is not designed to describe workflows or execution paths for a service. Instead, ALPS is designed to describe a shared set of data and actions elements that server MAY implement in order to create a service. Each action descriptor (where the descriptor's type property is set to 'safe', 'unsafe', or 'idemponent') SHOULD describe a state transition that a ALPS-compliant client application can invoke when it is available. Servers are free to implement the transitions they find useful and to arrange them in any order they wish.  ALPS-compliant client applications SHOULD be able to recognize these descriptors when they appear and are free to act upon them directly, render them for humans to invoke, or ignore/hide them completely.  </p>
 <h1 id="rfc.appendix.A.3"><a href="#rfc.appendix.A.3">A.3.</a> Why is there no way to indicate ranges for semantic descriptors?</h1>
-<p id="rfc.section.A.3.p.1">For most all service implementations, there are cases where it would be helpful to document a range of possible values for a semantic element. For example, when implementing the descriptor {"id":"size", ...}, one service might want to indicate the list of supported values such as: "small", "meduim", "large", etc. However, another service might have a very different list of possible values such as "standard", "oversized", "undersized", etc. And there may be a service that only supports a single value here and will always supply it ("onesie").  </p>
+<p id="rfc.section.A.3.p.1">For most all service implementations, there are cases where it would be helpful to document a range of possible values for a semantic element. For example, when implementing the descriptor {"id":"size", ...}, one service might want to indicate the list of supported values such as: 'small', 'meduim', 'large', etc. However, another service might have a very different list of possible values such as 'standard', 'oversized', 'undersized', etc. And there may be a service that only supports a single value here and will always supply it ('onesize').  </p>
 <p id="rfc.section.A.3.p.2">Since ALPS is meant to provide a single description that can be used by multiple services, establishing ranges within the ALPS description is considered over-constraining service implementations. Services are free to supply this information within representations at run time. But including them in the global ALPS profile is discouraged.  </p>
 <h1 id="rfc.authors">
   <a href="#rfc.authors">Authors' Addresses</a>


### PR DESCRIPTION
@mamund Please review and merge. 

This PR addresses and closes https://github.com/alps-io/spec/issues/63 and closes https://github.com/alps-io/spec/issues/61

W/r to quotes there are a few places double quotes are still used for emphasis in auto generated sections and quoting RFC2119.

This will be easiest to review by checking the individual commits e56bfad and 59a0a11.