### PR TITLE
Fixed descriptor type

### DIFF
--- a/schemas/spec/descriptor.json
+++ b/schemas/spec/descriptor.json
@@ -34,7 +34,11 @@
       "$ref": "definitions.json#/definitions/rel"
     },
     "descriptor": {
-      "$ref": "descriptor.json"
+      "type": "array",
+      "items": {
+        "type": "object",
+        "allOf": [{"$ref": "descriptor.json"}]
+      }
     }
   }
 }


### PR DESCRIPTION
Current json schema for descriptor is wrong.

ex.

- https://github.com/koriym/app-state-diagram/blob/master/docs/blog/profile.json
- https://github.com/koriym/app-state-diagram/blob/master/docs/todomvc/profile.json

Fixed descriptor type to array from object.

It is used the following profiles and verified by IDE.

- https://github.com/NaokiTsuchiya/app-state-diagram/blob/fix-example-schema/docs/blog/profile.json
- https://github.com/NaokiTsuchiya/app-state-diagram/blob/fix-example-schema/docs/todomvc/profile.json
- https://github.com/NaokiTsuchiya/LonelyState/blob/master/profile.json



